### PR TITLE
Refactor dataset pipeline and training framework

### DIFF
--- a/benchmark/download_semeval2018.sh
+++ b/benchmark/download_semeval2018.sh
@@ -1,3 +1,7 @@
+wget -P benchmark --no-check-certificate 'https://docs.google.com/uc?export=download&id=1dxzHQUrU6Za9d9Tib_jtj2s-B86EkqeS' -O benchmark/raw_semeval20181-1.zip
+unzip benchmark/raw_semeval20181-1.zip -d benchmark
+rm benchmark/raw_semeval20181-1.zip
+
 qmkdir -p benchmark/raw_semeval20181-2/Train benchmark/raw_semeval20181-2/Test
 
 wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.text.xml
@@ -8,5 +12,8 @@ wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/s
 wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.test.text.xml
 wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/keys.test.1.2.txt
 
-uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --dataset semeval20181-2 --path benchmark/raw_semeval20181-2/
+uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-1/
+uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-2/
+
+rm -r benchmark/raw_semeval20181-1
 rm -r benchmark/raw_semeval20181-2

--- a/benchmark/download_semeval20181-1.sh
+++ b/benchmark/download_semeval20181-1.sh
@@ -1,5 +1,0 @@
-wget -P benchmark --no-check-certificate 'https://docs.google.com/uc?export=download&id=1dxzHQUrU6Za9d9Tib_jtj2s-B86EkqeS' -O benchmark/raw_semeval20181-1.zip
-unzip benchmark/raw_semeval20181-1.zip -d benchmark
-rm benchmark/raw_semeval20181-1.zip
-uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --dataset semeval20181-1 --path benchmark/raw_semeval20181-1/
-rm -r benchmark/raw_semeval20181-1

--- a/deepref/dataset/example_generator.py
+++ b/deepref/dataset/example_generator.py
@@ -1,7 +1,6 @@
 from deepref.nlp.nlp_tool import NLPTool
 from deepref.nlp.semantic_knowledge import SemanticKNWL
 
-
 class ExampleGenerator:
     def __init__(self, nlp_tool: NLPTool):
         self.nlp_tool = nlp_tool
@@ -11,7 +10,14 @@ class ExampleGenerator:
         original_sentence = self.nlp_tool.untag_sentence(" ".join(tokens)).split()
         entity1, entity2 = self._get_entities(tokens, original_sentence)
         sk_entities = SemanticKNWL().extract([entity1['name'], entity2['name']])
-        return tokens, pos_tags, dependencies_labels, ner, original_sentence, entity1, entity2, relation_type, sk_entities
+        return {'original_sentence': original_sentence,
+                'e1': entity1,
+                'e2': entity2,
+                'relation_type': relation_type,
+                'pos_tags': pos_tags,
+                'dependencies_labels': dependencies_labels,
+                'ner': ner,
+                'sk_entities': sk_entities}
 
     def _get_entities(self, tokens, original_sentence):
         tokens = [t for t in tokens if t not in ("ENTITYUNRELATEDSTART", "ENTITYUNRELATEDEND")]

--- a/deepref/dataset/preprocessor/dataset_preprocessor.py
+++ b/deepref/dataset/preprocessor/dataset_preprocessor.py
@@ -62,7 +62,6 @@ class DatasetPreprocessor(ABC):
             example_dict = example_generator.generate(tagged_sentence, relation)
             for k, v in example_dict.items():
                 out[k].append(" ".join(v))
-                break
         df = pd.DataFrame(out)
         output_path = f"benchmark/{dataset_name}.csv"
         df.to_csv(output_path, sep='\t', encoding='utf-8', index=False)

--- a/deepref/dataset/preprocessor/ddi_preprocessor.py
+++ b/deepref/dataset/preprocessor/ddi_preprocessor.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     parser.add_argument("--path", required=True, help="Path to directory containing DDI XML files")
     args = parser.parse_args()
 
-    tool = SpacyNLPTool()
+    tool = SpacyNLPTool("en_core_web_trf")
 
     preprocessor = DDIPreprocessor()
-    preprocessor.write_dataframe("ddi", preprocessor.get_sentences(args.path), tool)
+    preprocessor.write_csv("ddi", preprocessor.get_sentences(args.path), tool)

--- a/deepref/dataset/preprocessor/semeval2018_preprocessor.py
+++ b/deepref/dataset/preprocessor/semeval2018_preprocessor.py
@@ -4,10 +4,11 @@ from pyexpat import ExpatError
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
-from deepref import config
 from deepref.dataset.preprocessor.dataset_preprocessor import DatasetPreprocessor
 
 from nltk.tokenize.punkt import PunktSentenceTokenizer, PunktParameters
+
+from deepref.nlp.spacy_nlp_tool import SpacyNLPTool
 
 class SemEval2018Preprocessor(DatasetPreprocessor):    
     def get_entity_dict(self, text_elements):
@@ -94,11 +95,15 @@ class SemEval2018Preprocessor(DatasetPreprocessor):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate CSV from raw SemEval2018 XML files")
-    parser.add_argument("--dataset", required=True, help="Dataset name (e.g. semeval20181-1, semeval20181-2)")
     parser.add_argument("--path", required=True, help="Path to directory containing SemEval2018 XML and txt files")
     args = parser.parse_args()
 
     preprocessor = SemEval2018Preprocessor()
     sentences = preprocessor.get_sentences(args.path)
-    print(sentences)
-    preprocessor.write_dataframe(args.dataset, preprocessor.get_sentences(args.path))
+    tool = SpacyNLPTool("en_core_web_trf")
+    if "semeval20181-1" in args.path:
+        preprocessor.write_csv("semeval20181-1", sentences, tool)
+    elif "semeval20181-2" in args.path:
+        preprocessor.write_csv("semeval20181-2", sentences, tool)
+    else:
+        raise ValueError("Invalid path")

--- a/deepref/dataset/text_transform.py
+++ b/deepref/dataset/text_transform.py
@@ -52,3 +52,12 @@ class BracketsOrParenthesisRemover(TextTransformer):
         tokens = text.split()
         tokens = [t for t in tokens if t not in ["(", ")", "[", "]"]]
         return " ".join(tokens)
+
+class TextTransformerPipeline(TextTransformer):
+    def __init__(self, *steps: TextTransformer):
+        self._steps = steps
+
+    def transform(self, text: str) -> str:
+        for step in self._steps:
+            text = step.transform(text)
+        return text

--- a/deepref/encoder/sdp_encoder.py
+++ b/deepref/encoder/sdp_encoder.py
@@ -28,18 +28,16 @@ import torch
 from deepref.encoder.sentence_encoder import SentenceEncoder
 
 
-class SDPEncoder:
+class SDPEncoder(SentenceEncoder):
     """Encode a sentence via the Shortest Dependency Path between two entities.
 
     Args:
+        model_name: HuggingFace model name (or local path) for the underlying
+            :class:`SentenceEncoder`.
         dep_vocab: ordered list of full dependency-relation names used as the
             one-hot vocabulary.  Defaults to an alphabetically sorted list of
             all relation names known to the encoder.
-        sentence_encoder_model: HuggingFace model name (or local path) passed
-            to :class:`SentenceEncoder` when *sentence_encoder* is not given.
-        device: PyTorch device string for the SentenceEncoder.
-        sentence_encoder: pre-built (or mock) SentenceEncoder instance.
-            When provided, *sentence_encoder_model* and *device* are ignored.
+        device: PyTorch device string passed to :class:`SentenceEncoder`.
     """
 
     # ------------------------------------------------------------------
@@ -102,21 +100,14 @@ class SDPEncoder:
 
     def __init__(
         self,
+        model_name: str = 'HuggingFaceTB/SmolLM-135M-Instruct',
         dep_vocab: Optional[list[str]] = None,
-        sentence_encoder_model: str = 'HuggingFaceTB/SmolLM-135M-Instruct',
         device: str = 'cpu',
-        sentence_encoder=None,
     ) -> None:
+        super().__init__(model_name, device=device)
+
         import spacy
         self.nlp = spacy.load('en_core_web_trf')
-
-        if sentence_encoder is not None:
-            self.sentence_encoder = sentence_encoder
-        else:
-            self.sentence_encoder = SentenceEncoder(
-                sentence_encoder_model,
-                device=device,
-            )
 
         if dep_vocab is None:
             dep_vocab = sorted(set(self.DEP_FULL_NAMES.values()))
@@ -279,7 +270,7 @@ class SDPEncoder:
         dep_chain = self.build_dep_chain(path)
         verbalized = self.verbalize(sentence, e1_name, e2_name, dep_chain)
 
-        return self.sentence_encoder(verbalized)
+        return self(verbalized)
 
     # ------------------------------------------------------------------
     # Private helpers

--- a/deepref/framework/sentence_re.py
+++ b/deepref/framework/sentence_re.py
@@ -13,8 +13,6 @@ import matplotlib.pyplot as plt
 
 import optuna
 
-from deepref import config
-
 class SentenceRE(nn.Module):
 
     def __init__(self, 
@@ -215,72 +213,72 @@ class SentenceRE(nn.Module):
         logging.info('Trained with dataset {}, model {}, embedding {} and preprocessing {}:\n'.format(self.dataset_name, model, embedding, self.preprocessing))
         logging.info('Hyperparams: {}'.format(hyper_params))
         time = datetime.now().isoformat(timespec="seconds")
-        os.makedirs(os.path.join(config.RESULTS_PATH, self.dataset_name, 'exp', time), exist_ok=True)
-        file_path = config.RESULTS_PATH+'/{}/exp/{}/{}_ResultsDeepREF_{}.txt'.format(self.dataset_name, time, time, self.dataset_name)
-        report = metrics.classification_report(ground_truth, pred, target_names=self.classes, digits=5, zero_division=1)
-        confusion_matrix = metrics.confusion_matrix(ground_truth, pred)
-        # for input, prediction, label in zip(inputs, pred, ground_truth):
-        #     if prediction != label:
-        #         print(input, 'has been classified as ', prediction, 'and should be ', label)
-        sns_plot = sns.heatmap(confusion_matrix, annot=True, xticklabels=self.classes, yticklabels=self.classes, cmap='binary', annot_kws={"fontsize":8}, linewidths=0.1, square=True)
-        #sns_plot.set_xticklabels(sns_plot.get_xmajorticklabels(), fontsize = 8)
-        #sns_plot.set_yticklabels(sns_plot.get_ymajorticklabels(), fontsize = 8)
-        fig = sns_plot.get_figure()
-        plt.gcf().set_size_inches(17, 15)
-        fig.savefig(f"{config.RESULTS_PATH}/{self.dataset_name}/exp/{time}/{self.dataset_name}_confusion_matrix.png")
-        plt.clf()
-        logging.info('\n'+report)
-        logging.info('Accuracy: {}'.format(result['acc']))
-        logging.info('Micro precision: {}'.format(result['micro_p']))
-        logging.info('Micro recall: {}'.format(result['micro_r']))
-        logging.info('Micro F1: {}'.format(result['micro_f1']))
-        logging.info('Macro F1: {}'.format(result['macro_f1']))
-        if os.path.isfile(file_path):
-            with open(file_path, 'a') as ablation_file:
-                self.write_test_results(ablation_file, model, embedding, hyper_params, result, report, confusion_matrix)
-        else:
-            with open(file_path, 'w') as ablation_file:
-                self.write_test_results(ablation_file, model, embedding, hyper_params, result, report, confusion_matrix)
+    #     os.makedirs(os.path.join(config.RESULTS_PATH, self.dataset_name, 'exp', time), exist_ok=True)
+    #     file_path = config.RESULTS_PATH+'/{}/exp/{}/{}_ResultsDeepREF_{}.txt'.format(self.dataset_name, time, time, self.dataset_name)
+    #     report = metrics.classification_report(ground_truth, pred, target_names=self.classes, digits=5, zero_division=1)
+    #     confusion_matrix = metrics.confusion_matrix(ground_truth, pred)
+    #     # for input, prediction, label in zip(inputs, pred, ground_truth):
+    #     #     if prediction != label:
+    #     #         print(input, 'has been classified as ', prediction, 'and should be ', label)
+    #     sns_plot = sns.heatmap(confusion_matrix, annot=True, xticklabels=self.classes, yticklabels=self.classes, cmap='binary', annot_kws={"fontsize":8}, linewidths=0.1, square=True)
+    #     #sns_plot.set_xticklabels(sns_plot.get_xmajorticklabels(), fontsize = 8)
+    #     #sns_plot.set_yticklabels(sns_plot.get_ymajorticklabels(), fontsize = 8)
+    #     fig = sns_plot.get_figure()
+    #     plt.gcf().set_size_inches(17, 15)
+    #     fig.savefig(f"{config.RESULTS_PATH}/{self.dataset_name}/exp/{time}/{self.dataset_name}_confusion_matrix.png")
+    #     plt.clf()
+    #     logging.info('\n'+report)
+    #     logging.info('Accuracy: {}'.format(result['acc']))
+    #     logging.info('Micro precision: {}'.format(result['micro_p']))
+    #     logging.info('Micro recall: {}'.format(result['micro_r']))
+    #     logging.info('Micro F1: {}'.format(result['micro_f1']))
+    #     logging.info('Macro F1: {}'.format(result['macro_f1']))
+    #     if os.path.isfile(file_path):
+    #         with open(file_path, 'a') as ablation_file:
+    #             self.write_test_results(ablation_file, model, embedding, hyper_params, result, report, confusion_matrix)
+    #     else:
+    #         with open(file_path, 'w') as ablation_file:
+    #             self.write_test_results(ablation_file, model, embedding, hyper_params, result, report, confusion_matrix)
 
-    def write_test_results(self, file, model, embedding, hyper_params, result, report, confusion_matrix):
-        embedding = embedding.replace('/', '-').replace('.', '')
-        file.write('Trained with dataset {}, model {}, embedding {} and preprocessing {}:\n'.format(self.dataset_name, model, embedding, self.preprocessing))
-        file.write('Hyperparams: {}'.format(hyper_params))
-        file.write('Confusion matrix:\n')
-        file.write(np.array2string(confusion_matrix)+'\n')
-        file.write('Test set results:\n')
-        file.write(report+"\n")
-        file.write('Accuracy: {}\n'.format(result['acc']))
-        file.write('Micro precision: {}\n'.format(result['micro_p']))
-        file.write('Micro recall: {}\n'.format(result['micro_r']))
-        file.write('Micro F1: {}\n\n'.format(result['micro_f1']))
-        file.write('Macro F1: {}\n\n'.format(result['macro_f1']))
+    # def write_test_results(self, file, model, embedding, hyper_params, result, report, confusion_matrix):
+    #     embedding = embedding.replace('/', '-').replace('.', '')
+    #     file.write('Trained with dataset {}, model {}, embedding {} and preprocessing {}:\n'.format(self.dataset_name, model, embedding, self.preprocessing))
+    #     file.write('Hyperparams: {}'.format(hyper_params))
+    #     file.write('Confusion matrix:\n')
+    #     file.write(np.array2string(confusion_matrix)+'\n')
+    #     file.write('Test set results:\n')
+    #     file.write(report+"\n")
+    #     file.write('Accuracy: {}\n'.format(result['acc']))
+    #     file.write('Micro precision: {}\n'.format(result['micro_p']))
+    #     file.write('Micro recall: {}\n'.format(result['micro_r']))
+    #     file.write('Micro F1: {}\n\n'.format(result['micro_f1']))
+    #     file.write('Macro F1: {}\n\n'.format(result['macro_f1']))
 
-    def results_per_epoch(self, ground_truth, pred, result, epoch):
-        logging.info(f'Epoch: {epoch}')
-        time = datetime.now().isoformat(timespec="seconds")
-        os.makedirs(os.path.join(config.RESULTS_PATH, self.dataset_name, 'exp', time), exist_ok=True)
-        file_path = config.RESULTS_PATH+'/{}/exp/{}/{}_ResultsDeepREF_{}_epoch_{}.txt'.format(self.dataset_name, time, time, self.dataset_name, epoch)
-        report = metrics.classification_report(ground_truth, pred, target_names=self.classes, digits=5, zero_division=1)
-        confusion_matrix = metrics.confusion_matrix(ground_truth, pred)
-        # for input, prediction, label in zip(inputs, pred, ground_truth):
-        #     if prediction != label:
-        #         print(input, 'has been classified as ', prediction, 'and should be ', label)
-        sns_plot = sns.heatmap(confusion_matrix, annot=True, xticklabels=self.classes, yticklabels=self.classes, cmap='binary', annot_kws={"fontsize":8}, linewidths=0.1, square=True)
-        #sns_plot.set_xticklabels(sns_plot.get_xmajorticklabels(), fontsize = 8)
-        #sns_plot.set_yticklabels(sns_plot.get_ymajorticklabels(), fontsize = 8)
-        fig = sns_plot.get_figure()
-        plt.gcf().set_size_inches(17, 15)
-        fig.savefig(f"{config.RESULTS_PATH}/{self.dataset_name}/exp/{time}/{self.dataset_name}_confusion_matrix.png")
-        plt.clf()
-        logging.info('\n'+report)
-        logging.info('Accuracy: {}'.format(result['acc']))
-        logging.info('Micro precision: {}'.format(result['micro_p']))
-        logging.info('Micro recall: {}'.format(result['micro_r']))
-        logging.info('Micro F1: {}'.format(result['micro_f1']))
-        logging.info('Macro F1: {}'.format(result['macro_f1']))
+    # def results_per_epoch(self, ground_truth, pred, result, epoch):
+    #     logging.info(f'Epoch: {epoch}')
+    #     time = datetime.now().isoformat(timespec="seconds")
+    #     os.makedirs(os.path.join(config.RESULTS_PATH, self.dataset_name, 'exp', time), exist_ok=True)
+    #     file_path = config.RESULTS_PATH+'/{}/exp/{}/{}_ResultsDeepREF_{}_epoch_{}.txt'.format(self.dataset_name, time, time, self.dataset_name, epoch)
+    #     report = metrics.classification_report(ground_truth, pred, target_names=self.classes, digits=5, zero_division=1)
+    #     confusion_matrix = metrics.confusion_matrix(ground_truth, pred)
+    #     # for input, prediction, label in zip(inputs, pred, ground_truth):
+    #     #     if prediction != label:
+    #     #         print(input, 'has been classified as ', prediction, 'and should be ', label)
+    #     sns_plot = sns.heatmap(confusion_matrix, annot=True, xticklabels=self.classes, yticklabels=self.classes, cmap='binary', annot_kws={"fontsize":8}, linewidths=0.1, square=True)
+    #     #sns_plot.set_xticklabels(sns_plot.get_xmajorticklabels(), fontsize = 8)
+    #     #sns_plot.set_yticklabels(sns_plot.get_ymajorticklabels(), fontsize = 8)
+    #     fig = sns_plot.get_figure()
+    #     plt.gcf().set_size_inches(17, 15)
+    #     fig.savefig(f"{config.RESULTS_PATH}/{self.dataset_name}/exp/{time}/{self.dataset_name}_confusion_matrix.png")
+    #     plt.clf()
+    #     logging.info('\n'+report)
+    #     logging.info('Accuracy: {}'.format(result['acc']))
+    #     logging.info('Micro precision: {}'.format(result['micro_p']))
+    #     logging.info('Micro recall: {}'.format(result['micro_r']))
+    #     logging.info('Micro F1: {}'.format(result['micro_f1']))
+    #     logging.info('Macro F1: {}'.format(result['macro_f1']))
 
 
-    def load_state_dict(self, state_dict):
-        self.model.load_state_dict(state_dict)
+    # def load_state_dict(self, state_dict):
+    #     self.model.load_state_dict(state_dict)
 

--- a/deepref/framework/train.py
+++ b/deepref/framework/train.py
@@ -2,318 +2,145 @@
 import torch
 import numpy as np
 import json
-import deepref
-from deepref import config
-from deepref.dataset.dataset import Dataset
-from deepref.dataset.preprocessors.stop_word_preprocessor import StopWordPreprocessor
-from deepref.dataset.preprocessors.punctuation_preprocessor import PunctuationPreprocessor
-from deepref.dataset.preprocessors.brackets_or_parenthesis_preprocessor import BracketsPreprocessor
-from deepref.dataset.preprocessors.digit_blinding_preprocessor import DigitBlindingPreprocessor
-from deepref.dataset.preprocessors.entity_blinding_preprocessor import EntityBlindingPreprocessor
-from deepref.framework.word_embedding_loader import WordEmbeddingLoader
-from benchmark.generate_parser import save2json, csv2id
 import os
 import sys
 import argparse
 import random
 
-class Training():
-        def __init__(self, dataset_name:str, parameters, trial=None, seed=42):
-                self.dataset_name = dataset_name
-                self.trial = trial
+from deepref.dataset.re_dataset import REDataset
+
+def __init__(self, dataset_name:str, parameters, trial=None, seed=42):
+        self.dataset_name = dataset_name
+        self.trial = trial
+
+        self.preprocessing = parameters["preprocessing"]
+        self.model = parameters["model"]
+        self.max_length = parameters["max_length"]
+        self.opt = "adamw" if self.model in ("bert_entity", "bert_cls", "ebem", "prompt_encoder") else "sgd"
+        self.pretrain = parameters["pretrain"]
+        self.position_embed = parameters["position_embed"]
+        self.pos_tags_embed = parameters["pos_tags_embed"]
+        self.deps_embed = parameters["deps_embed"]
+        self.batch_size = parameters["batch_size"]
+        self.lr = parameters["lr"]
+        self.max_epoch = parameters["max_epoch"]
         
-                self.preprocessing = parameters["preprocessing"]
-                self.model = parameters["model"]
-                self.max_length = parameters["max_length"]
-                self.opt = "adamw" if self.model in ("bert_entity", "bert_cls", "ebem", "prompt_encoder") else "sgd"
-                self.pretrain = parameters["pretrain"]
-                self.position_embed = parameters["position_embed"]
-                self.pos_tags_embed = parameters["pos_tags_embed"]
-                self.deps_embed = parameters["deps_embed"]
-                self.batch_size = parameters["batch_size"]
-                self.lr = parameters["lr"]
-                self.max_epoch = parameters["max_epoch"]
+        self.preprocessing = sorted(self.preprocessing)
+        print("preprocessing:",self.preprocessing)
+        if self.preprocessing != []:
+                self.preprocessing_str = "_".join(self.preprocessing)
+                print(self.preprocessing_str)
                 
-                self.preprocessing_str = 'original'
-                self.preprocessing = sorted(self.preprocessing)
-                print("preprocessing:",self.preprocessing)
-                if self.preprocessing != []:
-                        self.preprocessing_str = "_".join(self.preprocessing)
-                        print(self.preprocessing_str)
-                        
-                self.hyper_params = {
-                        "max_length": self.max_length,
-                        "max_epoch": self.max_epoch,                        
-                        "batch_size": self.batch_size,
-                        "lr": self.lr
-                }
+        self.hyper_params = {
+                "max_length": self.max_length,
+                "max_epoch": self.max_epoch,                        
+                "batch_size": self.batch_size,
+                "lr": self.lr
+        }       
+        
+        # Load data
+        dataset = REDataset(self.dataset_name)
+        
+
+        # Set random seed
+        self.set_seed(seed)
+
+        root_path = '.'
+        sys.path.append(root_path)
+        if not os.path.exists('ckpt'):
+                os.mkdir('ckpt')
+        ckpt = '{}_{}'.format(self.dataset_name, self.model)
+        self.ckpt = 'ckpt/{}.pth.tar'.format(ckpt)
+
+        if self.model == "bert_cls":
+                sentence_encoder = deepref.encoder.BERTEncoder(
+                        max_length=self.max_length, 
+                        pretrain_path=self.pretrain
+                )
                 
-                upos2id, deps2id = csv2id(self.dataset_name)
-                save2json(self.dataset_name, upos2id, deps2id)
-                upos2id = json.loads(open(os.path.join('benchmark', self.dataset_name, f"{self.dataset_name}_upos2id.json"), 'r').read())
-                deps2id = json.loads(open(os.path.join('benchmark', self.dataset_name, f"{self.dataset_name}_deps2id.json"), 'r').read())
-                        
-                
-                # Set random seed
-                self.set_seed(seed)
-
-                root_path = '.'
-                sys.path.append(root_path)
-                if not os.path.exists('ckpt'):
-                        os.mkdir('ckpt')
-                ckpt = '{}_{}'.format(self.dataset_name, self.model)
-                self.ckpt = 'ckpt/{}.pth.tar'.format(ckpt)
-                
-                self.train_file = ''
-                self.val_file = ''
-                self.test_file = ''
-                self.rel2id_file = ''
-                
-                if not os.path.exists(os.path.join(root_path, 'benchmark', self.dataset_name)):
-                        deepref.download(self.dataset_name, root_path=root_path)
-                        
-                self.train_file = os.path.join(root_path, 
-                                                'benchmark', 
-                                                self.dataset_name, 
-                                                self.preprocessing_str, 
-                                                '{}_train_{}.txt'.format(self.dataset_name, self.preprocessing_str))
-                self.val_file = os.path.join(root_path, 
-                                                'benchmark', 
-                                                self.dataset_name, 
-                                                self.preprocessing_str, 
-                                                '{}_val_{}.txt'.format(self.dataset_name, self.preprocessing_str))
-                self.test_file = os.path.join(root_path, 
-                                                'benchmark', 
-                                                self.dataset_name, 
-                                                self.preprocessing_str, 
-                                                '{}_test_{}.txt'.format(self.dataset_name, self.preprocessing_str))
-                        
-                if not (os.path.exists(self.train_file)) or not(os.path.exists(self.val_file)) or not(os.path.exists(self.test_file)):
-                        if 'sw' in self.preprocessing:
-                                dataset = StopWordPreprocessor(self.dataset_name, self.preprocessing).preprocess_dataset()
-                                dataset.write_text(self.preprocessing)
-                        if 'p' in self.preprocessing:
-                                dataset = PunctuationPreprocessor(self.dataset_name, self.preprocessing).preprocess_dataset()
-                                dataset.write_text(self.preprocessing)
-                        if 'b' in self.preprocessing:
-                                dataset = BracketsPreprocessor(self.dataset_name, self.preprocessing).preprocess_dataset()
-                                dataset.write_text(self.preprocessing)
-                        if 'd' in self.preprocessing:
-                                dataset = DigitBlindingPreprocessor(self.dataset_name, self.preprocessing).preprocess_dataset()
-                                dataset.write_text(self.preprocessing)
-                        if 'nb' in self.preprocessing and 'eb' in self.preprocessing:
-                                if self.dataset_name == 'ddi':
-                                        dataset = EntityBlindingPreprocessor(self.dataset_name, self.preprocessing, "DRUG").preprocess_dataset()
-                                        dataset.write_text(self.preprocessing)
-                                else:
-                                        dataset = EntityBlindingPreprocessor(self.dataset_name, self.preprocessing, "ENTITY").preprocess_dataset()
-                                        dataset.write_text(self.preprocessing)
-                        elif 'eb' in self.preprocessing:
-                                if self.dataset_name == 'ddi':
-                                        dataset = EntityBlindingPreprocessor(self.dataset_name, self. preprocessing, 'DRUG', 'entity').preprocess_dataset()
-                                        dataset.write_text(self.preprocessing)     
-                                else:
-                                        dataset = EntityBlindingPreprocessor(self.dataset_name, self. preprocessing, 'ENTITY', 'entity').preprocess_dataset()
-                                        dataset.write_text(self.preprocessing)
-                        elif 'nb' in self.preprocessing:
-                                if self.dataset_name == 'ddi':
-                                        dataset = EntityBlindingPreprocessor(self.dataset_name, self.preprocessing, "DRUG").preprocess_dataset()
-                                        dataset.write_text(self.preprocessing)
-                                else:
-                                        dataset = EntityBlindingPreprocessor(self.dataset_name, self.preprocessing, "ENTITY").preprocess_dataset()
-                                        dataset.write_text(self.preprocessing)
-                        
-                if not os.path.exists(self.test_file):
-                        self.test_file = None
-                self.rel2id_file = os.path.join(root_path, 'benchmark', self.dataset_name, '{}_rel2id.json'.format(self.dataset_name))
-                
-                rel2id = json.load(open(self.rel2id_file))
-
-                print("pretrain:",self.pretrain)
-                if 'bert_' not in self.model and self.model != 'ebem':
-                        print(self.model)
-                        word2id, word2vec = WordEmbeddingLoader("glove").load_embedding()
-                        word_dim = word2vec.shape[1]
-
-                # # Define the sentence encoder
-                # if self.model == "cnn":
-                #         sentence_encoder = deepref.encoder.CNNEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 kernel_size=3,
-                #                 padding_size=1,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #         )
-
-                # elif self.model == "pcnn":
-                #         sentence_encoder = deepref.encoder.PCNNEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 kernel_size=3,
-                #                 padding_size=1,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #         )
-
-                # elif self.model == "crcnn":
-                #         sentence_encoder = deepref.encoder.CRCNNEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 kernel_size=3,
-                #                 padding_size=1,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #         )
-
-                # elif self.model == "gru":
-                #         sentence_encoder = deepref.encoder.GRUEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #                 bidirectional=False
-                #         )
-                        
-                # elif self.model == "bigru":
-                #         sentence_encoder = deepref.encoder.GRUEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #                 bidirectional=True
-                #         )
-
-                # elif self.model == "lstm":
-                #         sentence_encoder = deepref.encoder.LSTMEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #                 bidirectional=False
-                #         )
-
-                # elif self.model == "bilstm":
-                #         sentence_encoder = deepref.encoder.LSTMEncoder(
-                #                 token2id=word2id,
-                #                 max_length=self.max_length,
-                #                 word_size=word_dim,
-                #                 position_size=5,
-                #                 hidden_size=230,
-                #                 blank_padding=True,
-                #                 word2vec=word2vec,
-                #                 dropout=0.5,
-                #                 bidirectional=True
-                #         )
-                        
-                elif self.model == "bert_cls":
-                        sentence_encoder = deepref.encoder.BERTEncoder(
-                                max_length=self.max_length, 
-                                pretrain_path=self.pretrain
-                        )
-                        
-                elif self.model == "bert_entity":
-                        sentence_encoder = deepref.encoder.BERTEntityEncoder(
-                                max_length=self.max_length,
-                                pretrain_path=self.pretrain
-                        )
-                
-                elif self.model == "ebem":
-                        sentence_encoder = deepref.encoder.EBEMEncoder(
-                                max_length=self.max_length,
-                                pretrain_path=self.pretrain,
-                                position_embedding=self.position_embed,
-                                pos_tags_embedding=self.pos_tags_embed,
-                                deps_embedding=self.deps_embed,
-                                upos2id=upos2id,
-                                deps2id=deps2id
-                        )
-
-                elif self.model == "sentence_encoder":
-                        sentence_encoder = deepref.encoder.SentenceEncoder(
-                                max_length=self.max_length,
-                                pretrain_path=self.pretrain
-                        )
-
-                elif self.model == "prompt_encoder":
-                        sentence_encoder = deepref.encoder.PromptEntityEncoder(
-                                max_length=self.max_length,
-                                pretrain_path=self.pretrain
-                        )
-
-                # Define the model
-                self.model_deepref = deepref.model.SoftmaxNN(sentence_encoder, len(rel2id), rel2id)
-                
-                self.criterion = deepref.model.PairwiseRankingLoss() if self.model == 'crcnn' else None
-                
-        def set_seed(self, seed):
-                random.seed(seed)
-                np.random.seed(seed)
-                torch.manual_seed(seed)
-                torch.cuda.manual_seed(seed)
-                        
-        def train(self):
-
-                # Define the whole training framework
-                framework = deepref.framework.SentenceRE(
-                        train_path=self.train_file,
-                        val_path=self.val_file,
-                        test_path=self.test_file,
-                        model=self.model_deepref,
-                        ckpt=self.ckpt,
-                        batch_size=self.batch_size,
-                        max_epoch=self.max_epoch,
-                        lr=self.lr,
-                        opt=self.opt,
-                        criterion=self.criterion,
-                        trial=self.trial,
+        elif self.model == "bert_entity":
+                sentence_encoder = deepref.encoder.BERTEntityEncoder(
+                        max_length=self.max_length,
+                        pretrain_path=self.pretrain
+                )
+        
+        elif self.model == "ebem":
+                sentence_encoder = deepref.encoder.EBEMEncoder(
+                        max_length=self.max_length,
+                        pretrain_path=self.pretrain,
+                        position_embedding=self.position_embed,
+                        pos_tags_embedding=self.pos_tags_embed,
+                        deps_embedding=self.deps_embed,
+                        #upos2id=upos2id,
+                        #deps2id=deps2id
                 )
 
-                # Train the model
-                try:
-                        framework.train_model()
-                except RuntimeError as e:
-                        if 'out of memory' in str(e):
-                                print(" | WARNING: ran out of memory")
-                                for p in framework.model.parameters():
-                                        if p .grad is not None:
-                                                del p.grad
-                                torch.cuda.empty_cache()
-                                return {"acc": 0, "micro_p": 0, "micro_r": 0, "micro_f1": 0, "macro_f1": 0}
-                        
-                # Test
-                result, pred, ground_truth = framework.eval_model(framework.test_loader)
+        elif self.model == "sentence_encoder":
+                sentence_encoder = deepref.encoder.SentenceEncoder(
+                        max_length=self.max_length,
+                        pretrain_path=self.pretrain
+                )
 
-                # Print the result
-                framework.test_set_results(ground_truth, pred, result, self.model, self.pretrain, self.hyper_params)
+        elif self.model == "prompt_encoder":
+                sentence_encoder = deepref.encoder.PromptEntityEncoder(
+                        max_length=self.max_length,
+                        pretrain_path=self.pretrain
+                )
+
+        elif self.model == "sdp_encoder":
+                sentence_encoder = deepref.encoder.SDPEncoder(
+                        max_length=self.max_length,
+                        pretrain_path=self.pretrain
+                )
+
+        # Define the model
+        self.model_deepref = deepref.model.SoftmaxMLP(sentence_encoder, len(rel2id), rel2id)
+        
+        self.criterion = deepref.model.PairwiseRankingLoss() if self.model == 'crcnn' else None
+        
+def set_seed(self, seed):
+        random.seed(seed)
+        np.random.seed(seed)
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed(seed)
                 
-                torch.cuda.empty_cache()
+def train(self):
+
+        # Define the whole training framework
+        framework = deepref.framework.SentenceRETrainer(
+                train_dataset=self.train_file,
+                test_dataset=self.test_file,
+                model=self.model_deepref,
+                ckpt=self.ckpt,
+                batch_size=self.batch_size,
+                max_epoch=self.max_epoch,
+                lr=self.lr,
+                opt=self.opt,
+                criterion=self.criterion,
+                trial=self.trial,
+        )
+
+        # Train the model
+        try:
+                framework.train_model()
+        except RuntimeError as e:
+                if 'out of memory' in str(e):
+                        print(" | WARNING: ran out of memory")
+                        for p in framework.model.parameters():
+                                if p .grad is not None:
+                                        del p.grad
+                        torch.cuda.empty_cache()
+                        return {"acc": 0, "micro_p": 0, "micro_r": 0, "micro_f1": 0, "macro_f1": 0}
                 
-                return result
+        # Test
+        result, pred, ground_truth = framework.eval_model(framework.test_loader)
+
+        # Print the result
+        framework.test_set_results(ground_truth, pred, result, self.model, self.pretrain, self.hyper_params)
+        
+        torch.cuda.empty_cache()
+        
+        return result
                 
 if __name__ == '__main__':
 


### PR DESCRIPTION
## Summary

- Consolidate `download_semeval20181-1.sh` and `download_semeval20181-2.sh` into a single `download_semeval2018.sh`
- Refactor `DatasetPreprocessor` as an ABC with `TextTransformerPipeline`
- Update `REDataset` interface in `re_dataset.py`
- Refactor `sentence_re.py` and `train.py` for updated encoder hierarchy
- Extend `test_re_dataset.py` with additional coverage

## Test plan

- [ ] Run `pytest deepref/tests/dataset/` to verify dataset tests pass
- [ ] Run `bash benchmark/download_semeval2018.sh` to verify download script works

🤖 Generated with [Claude Code](https://claude.com/claude-code)