### PR TITLE
Add combine-embeddings experiment with natural train/test splits

### DIFF
--- a/benchmark/download_semeval2010.sh
+++ b/benchmark/download_semeval2010.sh
@@ -1,5 +1,7 @@
 mkdir -p benchmark/raw_semeval2010
-wget -P benchmark/raw_semeval2010 https://raw.githubusercontent.com/sahitya0000/Relation-Classification/master/corpus/SemEval2010_task8_training/TRAIN_FILE.TXT
-wget -P benchmark/raw_semeval2010 https://raw.githubusercontent.com/sahitya0000/Relation-Classification/master/corpus/SemEval2010_task8_testing_keys/TEST_FILE_FULL.TXT
+wget -P benchmark/raw_semeval2010 https://raw.githubusercontent.com/sahitya0000/Relation-Classification/master/corpus/SemEval2010_task8_training/TRAIN_FILE.TXT & wget -P benchmark/raw_semeval2010 https://raw.githubusercontent.com/sahitya0000/Relation-Classification/master/corpus/SemEval2010_task8_testing_keys/TEST_FILE_FULL.TXT &
+
+wait
+
 uv run python deepref/dataset/preprocessor/semeval2010_preprocessor.py --path benchmark/raw_semeval2010/
 rm -r benchmark/raw_semeval2010

--- a/benchmark/download_semeval2018.sh
+++ b/benchmark/download_semeval2018.sh
@@ -2,18 +2,16 @@ wget -P benchmark --no-check-certificate 'https://docs.google.com/uc?export=down
 unzip benchmark/raw_semeval20181-1.zip -d benchmark
 rm benchmark/raw_semeval20181-1.zip
 
-qmkdir -p benchmark/raw_semeval20181-2/Train benchmark/raw_semeval20181-2/Test
+mkdir -p benchmark/raw_semeval20181-2/Train benchmark/raw_semeval20181-2/Test
 
-wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.text.xml
-wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.relations.txt
-wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.text.xml
-wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.relations.txt
+wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.text.xml & wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.relations.txt & wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.text.xml & wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.relations.txt &
 
-wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.test.text.xml
-wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/keys.test.1.2.txt
+wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.test.text.xml & wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/keys.test.1.2.txt &
 
-uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-1/
-uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-2/
+wait
 
-rm -r benchmark/raw_semeval20181-1
-rm -r benchmark/raw_semeval20181-2
+uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-1/ & uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-2/ &
+
+wait
+
+rm -r benchmark/raw_semeval20181-1 & rm -r benchmark/raw_semeval20181-2 &

--- a/benchmark/download_semeval2018.sh
+++ b/benchmark/download_semeval2018.sh
@@ -1,16 +1,15 @@
-wget -P benchmark --no-check-certificate 'https://docs.google.com/uc?export=download&id=1dxzHQUrU6Za9d9Tib_jtj2s-B86EkqeS' -O benchmark/raw_semeval20181-1.zip
-unzip benchmark/raw_semeval20181-1.zip -d benchmark
-rm benchmark/raw_semeval20181-1.zip
-
+mkdir -p benchmark/raw_semeval20181-1/Train benchmark/raw_semeval20181-1/Test
 mkdir -p benchmark/raw_semeval20181-2/Train benchmark/raw_semeval20181-2/Test
 
-wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.text.xml & wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.1.relations.txt & wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.text.xml & wget -P benchmark/raw_semeval20181-2/Train https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.relations.txt &
+wget -P benchmark/raw_semeval20181-1/Train https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.1.text.xml & wget -P benchmark/raw_semeval20181-1/Train https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.1.relations.txt &
+wget -P benchmark/raw_semeval20181-1/Test https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.1.test.text.xml & wget -P benchmark/raw_semeval20181-1/Test https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.1.test.relations.txt &
 
-wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/1.2.test.text.xml & wget -P benchmark/raw_semeval20181-2/Test https://lipn.univ-paris13.fr/~gabor/semeval2018task7/keys.test.1.2.txt &
+wget -P benchmark/raw_semeval20181-2/Train https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.2.text.xml & wget -P benchmark/raw_semeval20181-2/Train https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.2.relations.txt &
+wget -P benchmark/raw_semeval20181-2/Test https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.2.test.text.xml & wget -P benchmark/raw_semeval20181-2/Test https://raw.githubusercontent.com/gkata/SemEval2018Task7/testing/1.2.test.relations.txt &
 
 wait
 
-uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-1/ & uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-2/ &
+uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-1/ 2>&1 | sed -u 's/^/[job1] /' & uv run python deepref/dataset/preprocessor/semeval2018_preprocessor.py --path benchmark/raw_semeval20181-2/ 2>&1 | sed -u 's/^/[job2] /' &
 
 wait
 

--- a/deepref/dataset/preprocessor/ddi_preprocessor.py
+++ b/deepref/dataset/preprocessor/ddi_preprocessor.py
@@ -56,6 +56,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     tool = SpacyNLPTool("en_core_web_trf")
-
     preprocessor = DDIPreprocessor()
-    preprocessor.write_csv("ddi", preprocessor.get_sentences(args.path), tool)
+
+    base = Path(args.path)
+    train_path = next((p for p in base.rglob("Train") if p.is_dir()), None)
+    test_path = next((p for p in base.rglob("Test") if p.is_dir()), None)
+
+    if train_path and test_path:
+        train_sentences = list(preprocessor.get_sentences(str(train_path)))
+        test_sentences = list(preprocessor.get_sentences(str(test_path)))
+        preprocessor.write_split_csvs("ddi", train_sentences, test_sentences, tool)
+    else:
+        preprocessor.write_csv("ddi", preprocessor.get_sentences(args.path), tool)

--- a/deepref/dataset/preprocessor/semeval2010_preprocessor.py
+++ b/deepref/dataset/preprocessor/semeval2010_preprocessor.py
@@ -51,10 +51,8 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     preprocessor = SemEval2010Preprocessor()
-    data = (
-        list(preprocessor.get_sentences(os.path.join(args.path, "TRAIN_FILE.TXT"))) +
-        list(preprocessor.get_sentences(os.path.join(args.path, "TEST_FILE_FULL.TXT")))
-    )
+    train_sentences = list(preprocessor.get_sentences(os.path.join(args.path, "TRAIN_FILE.TXT")))
+    test_sentences = list(preprocessor.get_sentences(os.path.join(args.path, "TEST_FILE_FULL.TXT")))
     tool = SpacyNLPTool("en_core_web_trf")
 
-    preprocessor.write_csv("semeval2010", data, tool)
+    preprocessor.write_split_csvs("semeval2010", train_sentences, test_sentences, tool)

--- a/deepref/dataset/preprocessor/semeval2018_preprocessor.py
+++ b/deepref/dataset/preprocessor/semeval2018_preprocessor.py
@@ -98,12 +98,23 @@ if __name__ == "__main__":
     parser.add_argument("--path", required=True, help="Path to directory containing SemEval2018 XML and txt files")
     args = parser.parse_args()
 
-    preprocessor = SemEval2018Preprocessor()
-    sentences = preprocessor.get_sentences(args.path)
-    tool = SpacyNLPTool("en_core_web_trf")
     if "semeval20181-1" in args.path:
-        preprocessor.write_csv("semeval20181-1", sentences, tool)
+        dataset_name = "semeval20181-1"
     elif "semeval20181-2" in args.path:
-        preprocessor.write_csv("semeval20181-2", sentences, tool)
+        dataset_name = "semeval20181-2"
     else:
-        raise ValueError("Invalid path")
+        raise ValueError("Invalid path: must contain 'semeval20181-1' or 'semeval20181-2'")
+
+    preprocessor = SemEval2018Preprocessor()
+    tool = SpacyNLPTool("en_core_web_trf")
+
+    base = Path(args.path)
+    train_path = next((p for p in base.rglob("Train") if p.is_dir()), None)
+    test_path = next((p for p in base.rglob("Test") if p.is_dir()), None)
+
+    if train_path and test_path:
+        train_sentences = list(preprocessor.get_sentences(str(train_path)))
+        test_sentences = list(preprocessor.get_sentences(str(test_path)))
+        preprocessor.write_split_csvs(dataset_name, train_sentences, test_sentences, tool)
+    else:
+        preprocessor.write_csv(dataset_name, preprocessor.get_sentences(args.path), tool)

--- a/deepref/encoder/llm_encoder.py
+++ b/deepref/encoder/llm_encoder.py
@@ -4,6 +4,11 @@ from transformers import AutoModel, AutoTokenizer
 
 from deepref.encoder.sentence_encoder import SentenceEncoder
 
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent.parent
+CACHE_DIR = str(BASE_DIR / "tmp")
+
 
 class LLMEncoder(SentenceEncoder):
     """Concrete sentence encoder backed by a HuggingFace transformer.
@@ -37,6 +42,8 @@ class LLMEncoder(SentenceEncoder):
             trust_remote_code=True,
             torch_dtype=torch.float16,
             attn_implementation=attn_implementation,
+            cache_dir=CACHE_DIR
+            
         ).to(device)
 
         if not trainable:

--- a/deepref/experiments/conf/combine_experiment.yaml
+++ b/deepref/experiments/conf/combine_experiment.yaml
@@ -11,7 +11,7 @@ mlflow:
 training:
   lr: 2.0e-5
   max_epoch: 5
-  batch_size: 16
+  batch_size: 32
   num_mlp_layers: 3
   dropout: 0.1
   opt: adamw

--- a/deepref/experiments/conf/combine_experiment.yaml
+++ b/deepref/experiments/conf/combine_experiment.yaml
@@ -14,10 +14,9 @@ training:
   batch_size: 16
   num_mlp_layers: 3
   dropout: 0.1
-  opt: adam
+  opt: adamw
   weight_decay: 0.0
   warmup_step: 0
-  train_ratio: 0.8
   seed: 42
 
-device: cpu
+device: cuda

--- a/deepref/experiments/conf/combine_experiment.yaml
+++ b/deepref/experiments/conf/combine_experiment.yaml
@@ -1,0 +1,23 @@
+defaults:
+  - encoder1: relation
+  - encoder2: bow_sdp
+  - dataset: semeval2010
+  - _self_
+
+mlflow:
+  experiment_name: combine_embeddings_experiment
+  tracking_uri: null
+
+training:
+  lr: 2.0e-5
+  max_epoch: 5
+  batch_size: 16
+  num_mlp_layers: 3
+  dropout: 0.1
+  opt: adam
+  weight_decay: 0.0
+  warmup_step: 0
+  train_ratio: 0.8
+  seed: 42
+
+device: cpu

--- a/deepref/experiments/conf/dataset/ddi.yaml
+++ b/deepref/experiments/conf/dataset/ddi.yaml
@@ -1,4 +1,5 @@
 # @package _global_
 dataset:
   name: ddi
-  csv_path: benchmark/ddi.csv
+  train_csv_path: benchmark/ddi_train.csv
+  test_csv_path: benchmark/ddi_test.csv

--- a/deepref/experiments/conf/dataset/ddi.yaml
+++ b/deepref/experiments/conf/dataset/ddi.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+dataset:
+  name: ddi
+  csv_path: benchmark/ddi.csv

--- a/deepref/experiments/conf/dataset/semeval2010.yaml
+++ b/deepref/experiments/conf/dataset/semeval2010.yaml
@@ -1,4 +1,5 @@
 # @package _global_
 dataset:
   name: semeval2010
-  csv_path: benchmark/semeval2010.csv
+  train_csv_path: benchmark/semeval2010_train.csv
+  test_csv_path: benchmark/semeval2010_test.csv

--- a/deepref/experiments/conf/dataset/semeval2010.yaml
+++ b/deepref/experiments/conf/dataset/semeval2010.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+dataset:
+  name: semeval2010
+  csv_path: benchmark/semeval2010.csv

--- a/deepref/experiments/conf/dataset/semeval20181-1.yaml
+++ b/deepref/experiments/conf/dataset/semeval20181-1.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+dataset:
+  name: semeval20181-1
+  train_csv_path: benchmark/semeval20181-1_train.csv
+  test_csv_path: benchmark/semeval20181-1_test.csv

--- a/deepref/experiments/conf/dataset/semeval20181-2.yaml
+++ b/deepref/experiments/conf/dataset/semeval20181-2.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+dataset:
+  name: semeval20181-2
+  train_csv_path: benchmark/semeval20181-2_train.csv
+  test_csv_path: benchmark/semeval20181-2_test.csv

--- a/deepref/experiments/conf/encoder1/llm.yaml
+++ b/deepref/experiments/conf/encoder1/llm.yaml
@@ -1,6 +1,7 @@
 # @package _global_
 encoder1:
   type: llm
-  model_name: Qwen/Qwen3-Embedding-8B
-  max_length: 8192
+  model_name: HuggingFaceTB/SmolLM-135M-Instruct
+  max_length: 128
   trainable: false
+  attn_implementation: sdpa

--- a/deepref/experiments/conf/encoder1/llm.yaml
+++ b/deepref/experiments/conf/encoder1/llm.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 encoder1:
   type: llm
-  model_name: HuggingFaceTB/SmolLM-135M-Instruct
-  max_length: 128
+  model_name: Qwen/Qwen3-Embedding-8B
+  max_length: 8192
   trainable: false

--- a/deepref/experiments/conf/encoder1/llm.yaml
+++ b/deepref/experiments/conf/encoder1/llm.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+encoder1:
+  type: llm
+  model_name: HuggingFaceTB/SmolLM-135M-Instruct
+  max_length: 128
+  trainable: false

--- a/deepref/experiments/conf/encoder1/relation.yaml
+++ b/deepref/experiments/conf/encoder1/relation.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 encoder1:
   type: relation
-  model_name: bert-base-uncased
+  model_name: rel-emb-bert-b-uncased
   max_length: 128
   trainable: false

--- a/deepref/experiments/conf/encoder1/relation.yaml
+++ b/deepref/experiments/conf/encoder1/relation.yaml
@@ -1,0 +1,6 @@
+# @package _global_
+encoder1:
+  type: relation
+  model_name: bert-base-uncased
+  max_length: 128
+  trainable: false

--- a/deepref/experiments/conf/encoder1/relation.yaml
+++ b/deepref/experiments/conf/encoder1/relation.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 encoder1:
   type: relation
-  model_name: rel-emb-bert-b-uncased
+  model_name: bert-base-uncased
   max_length: 128
   trainable: false

--- a/deepref/experiments/conf/encoder2/bow_sdp.yaml
+++ b/deepref/experiments/conf/encoder2/bow_sdp.yaml
@@ -1,0 +1,3 @@
+# @package _global_
+encoder2:
+  type: bow_sdp

--- a/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
+++ b/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
@@ -1,0 +1,4 @@
+# @package _global_
+encoder2:
+  type: verbalized_sdp
+  model_name: HuggingFaceTB/SmolLM-135M-Instruct

--- a/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
+++ b/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
@@ -1,4 +1,4 @@
 # @package _global_
 encoder2:
   type: verbalized_sdp
-  model_name: Qwen/Qwen3-Embedding-8B
+  model_name: HuggingFaceTB/SmolLM-135M-Instruct

--- a/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
+++ b/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
@@ -1,4 +1,4 @@
 # @package _global_
 encoder2:
   type: verbalized_sdp
-  model_name: HuggingFaceTB/SmolLM-135M-Instruct
+  model_name: Qwen/Qwen3-Embedding-8B

--- a/deepref/experiments/run_combine_embeddings_experiments.py
+++ b/deepref/experiments/run_combine_embeddings_experiments.py
@@ -297,8 +297,8 @@ class CombineRETrainer(SentenceRETrainer):
     def __init__(
         self,
         model: SoftmaxMLP,
-        train_dataset: Subset,
-        test_dataset: Subset,
+        train_dataset: REDataset,
+        test_dataset: REDataset,
         ckpt: str,
         training_parameters: dict[str, Any],
     ) -> None:
@@ -529,6 +529,7 @@ def build_encoder1(cfg: DictConfig, device: str) -> nn.Module:
             max_length=enc.max_length,
             device=device,
             trainable=enc.trainable,
+            attn_implementation=enc.attn_implementation,
         )
     raise ValueError(f"Unknown encoder1 type: {enc.type!r}")
 

--- a/deepref/experiments/run_combine_embeddings_experiments.py
+++ b/deepref/experiments/run_combine_embeddings_experiments.py
@@ -1,0 +1,656 @@
+"""
+Combine-Embeddings experiment runner.
+
+Trains a SoftmaxMLP classifier on top of two concatenated encoders using
+SentenceRETrainer as the training engine.
+
+Four encoder combinations (driven by Hydra multirun):
+  encoder1=relation  encoder2=bow_sdp
+  encoder1=relation  encoder2=verbalized_sdp
+  encoder1=llm       encoder2=bow_sdp
+  encoder1=llm       encoder2=verbalized_sdp
+
+Usage
+-----
+Single run (defaults: relation + bow_sdp, semeval2010):
+    python deepref/experiments/run_combine_embeddings_experiments.py
+
+All 4 encoder combinations via multirun:
+    python deepref/experiments/run_combine_embeddings_experiments.py \\
+        --multirun encoder1=relation,llm encoder2=bow_sdp,verbalized_sdp
+
+Cross dataset × encoder multirun:
+    python deepref/experiments/run_combine_embeddings_experiments.py \\
+        --multirun \\
+        dataset=semeval2010,ddi \\
+        encoder1=relation,llm \\
+        encoder2=bow_sdp,verbalized_sdp
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import hydra
+import mlflow
+import torch
+import torch.nn as nn
+from omegaconf import DictConfig, OmegaConf
+from sklearn.metrics import (
+    accuracy_score,
+    f1_score,
+    precision_score,
+    recall_score,
+)
+from sklearn.model_selection import train_test_split
+from torch import optim
+from torch.utils.data import DataLoader, Subset
+from tqdm import tqdm
+
+from deepref.dataset.re_dataset import REDataset
+from deepref.encoder.llm_encoder import LLMEncoder
+from deepref.encoder.relation_encoder import RelationEncoder
+from deepref.encoder.sdp_encoder import BoWSDPEncoder, VerbalizedSDPEncoder
+from deepref.framework.sentence_re_trainer import SentenceRETrainer
+from deepref.framework.utils import AverageMeter
+from deepref.model.softmax_mlp import SoftmaxMLP
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Dataset
+# ---------------------------------------------------------------------------
+
+class CombineREDataset(REDataset):
+    """REDataset subclass that returns raw item dicts instead of tokenized tensors.
+
+    Each sample is returned as a ``(item_dict, label_tensor)`` pair where
+    ``item_dict`` contains the keys expected by all supported encoders:
+
+    * ``'token'``: list of str tokens from the original sentence.
+    * ``'h'``: ``{'name': str, 'pos': [start, end_exclusive]}`` — head entity.
+    * ``'t'``: ``{'name': str, 'pos': [start, end_exclusive]}`` — tail entity.
+
+    Bypasses the tokenizer dependency of the base :class:`REDataset` since
+    combined encoders perform their own tokenization internally.
+    """
+
+    def __init__(self, csv_path: str) -> None:
+        # Replicate only the DataFrame + rel2id parts of REDataset.__init__
+        # to avoid requiring a HuggingFace tokenizer at the dataset level.
+        self.df = self.get_dataframe(csv_path)
+        self.rel2id = self.get_labels_dict()
+        self.pipeline = None
+        self.max_length = 0
+
+    def __getitem__(self, index: int) -> tuple[dict, torch.Tensor]:
+        row = self.df.iloc[index]
+
+        tokens: list[str] = row["original_sentence"].split()
+        e1: dict = ast.literal_eval(row["e1"])
+        e2: dict = ast.literal_eval(row["e2"])
+
+        item = {
+            "token": tokens,
+            "h": {"name": e1["name"], "pos": e1["position"]},
+            "t": {"name": e2["name"], "pos": e2["position"]},
+        }
+        label = torch.tensor(self.rel2id[row["relation_type"]], dtype=torch.long)
+        return item, label
+
+
+def combine_collate_fn(
+    batch: list[tuple[dict, torch.Tensor]],
+) -> dict[str, Any]:
+    """Collate ``(item_dict, label)`` pairs into a batch dict.
+
+    Returns a dict with:
+    * ``"labels"``: ``(B,)`` long tensor — compatible with
+      :meth:`SentenceRETrainer.iterate_loader`.
+    * ``"items"``: plain Python list of item dicts — passed as the
+      ``items`` keyword argument to :class:`CombineEmbeddings`.
+    """
+    items, labels = zip(*batch)
+    return {"labels": torch.stack(labels), "items": list(items)}
+
+
+def make_split_subsets(
+    dataset: CombineREDataset,
+    train_ratio: float,
+    seed: int,
+) -> tuple[Subset, Subset]:
+    """Return train and test :class:`~torch.utils.data.Subset` instances."""
+    indices = list(range(len(dataset)))
+    train_idx, test_idx = train_test_split(
+        indices,
+        train_size=train_ratio,
+        random_state=seed,
+        shuffle=True,
+    )
+    logger.info("Dataset split — train: %d  test: %d", len(train_idx), len(test_idx))
+    return Subset(dataset, train_idx), Subset(dataset, test_idx)
+
+
+# ---------------------------------------------------------------------------
+# Combined encoder
+# ---------------------------------------------------------------------------
+
+class CombineEmbeddings(nn.Module):
+    """Concatenate embeddings from two independent encoders.
+
+    Supports any combination of:
+    * :class:`~deepref.encoder.relation_encoder.RelationEncoder`
+    * :class:`~deepref.encoder.llm_encoder.LLMEncoder`
+    * :class:`~deepref.encoder.sdp_encoder.BoWSDPEncoder`
+    * :class:`~deepref.encoder.sdp_encoder.VerbalizedSDPEncoder`
+
+    The combined output dimension equals ``hidden_size(encoder1) +
+    hidden_size(encoder2)`` and is exposed via ``self.model.config.hidden_size``
+    so that :class:`~deepref.model.softmax_mlp.SoftmaxMLP` (and the underlying
+    :class:`~deepref.module.nn.mlp.MLP`) can consume this encoder without
+    modification.
+
+    Args:
+        encoder1: first encoder instance.
+        encoder2: second encoder instance.
+    """
+
+    def __init__(self, encoder1: nn.Module, encoder2: nn.Module) -> None:
+        super().__init__()
+        self.encoder1 = encoder1
+        self.encoder2 = encoder2
+
+        h1 = self._get_hidden_size(encoder1)
+        h2 = self._get_hidden_size(encoder2)
+        combined = h1 + h2
+
+        # Expose model.config.hidden_size for SoftmaxMLP / MLP compatibility.
+        self.model = SimpleNamespace(
+            config=SimpleNamespace(hidden_size=combined)
+        )
+        logger.info(
+            "CombineEmbeddings — encoder1: %d  encoder2: %d  combined: %d",
+            h1, h2, combined,
+        )
+
+    # ------------------------------------------------------------------
+    # Hidden-size helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_hidden_size(encoder: nn.Module) -> int:
+        """Return the output dimensionality of *encoder* for a single sample."""
+        # RelationEncoder sets self.hidden_size = 3 * model.config.hidden_size
+        if isinstance(encoder, RelationEncoder):
+            return encoder.hidden_size
+        # BoWSDPEncoder has no neural model; output = dep_vocab length
+        if isinstance(encoder, BoWSDPEncoder):
+            return len(encoder.dep_vocab)
+        # LLMEncoder (and VerbalizedSDPEncoder which inherits it)
+        if isinstance(encoder, LLMEncoder):
+            return encoder.model.config.hidden_size
+        raise ValueError(
+            f"Cannot determine hidden size for encoder type: {type(encoder)}"
+        )
+
+    # ------------------------------------------------------------------
+    # Per-encoder encode helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _encode_single(encoder: nn.Module, item: dict) -> torch.Tensor:
+        """Encode one sample and return a 1-D float32 embedding tensor.
+
+        Each encoder has a different forward signature; this method dispatches
+        appropriately.  Return shape is always ``(H,)`` so outputs can be
+        concatenated with ``torch.cat``.
+
+        .. note::
+            :class:`RelationEncoder` and :class:`VerbalizedSDPEncoder` are
+            checked *before* their parent :class:`LLMEncoder` because both
+            are subclasses of it.
+        """
+        if isinstance(encoder, RelationEncoder):
+            token, att_mask, pos_e1, pos_e2, pos_mask = encoder.tokenize(item)
+            emb = encoder.forward(token, att_mask, pos_e1, pos_e2, pos_mask)
+            return emb.squeeze(0).float()  # (3H,)
+
+        if isinstance(encoder, VerbalizedSDPEncoder):
+            emb = encoder.forward(item)    # (1, H)
+            return emb.squeeze(0).float()  # (H,)
+
+        if isinstance(encoder, BoWSDPEncoder):
+            return encoder.forward(item).float()  # (len_dep_vocab,)
+
+        if isinstance(encoder, LLMEncoder):
+            text = " ".join(item["token"])
+            emb = encoder.forward(text)    # (1, H)
+            return emb.squeeze(0).float()  # (H,)
+
+        raise ValueError(f"Unsupported encoder type: {type(encoder)}")
+
+    # ------------------------------------------------------------------
+    # Forward — called as combine_emb(items=batch_list) by SoftmaxMLP
+    # ------------------------------------------------------------------
+
+    def forward(self, items: list[dict]) -> torch.Tensor:
+        """Encode a batch of items and return concatenated embeddings.
+
+        Args:
+            items: list of item dicts with ``'token'``, ``'h'``, and ``'t'``
+                keys (as returned by :class:`CombineREDataset`).
+
+        Returns:
+            Float32 tensor of shape ``(B, H1 + H2)``.
+        """
+        batch_embs: list[torch.Tensor] = []
+        for item in items:
+            emb1 = self._encode_single(self.encoder1, item)
+            emb2 = self._encode_single(self.encoder2, item)
+            batch_embs.append(torch.cat([emb1, emb2], dim=0))
+        return torch.stack(batch_embs, dim=0)  # (B, H1+H2)
+
+
+# ---------------------------------------------------------------------------
+# Trainer
+# ---------------------------------------------------------------------------
+
+class CombineRETrainer(SentenceRETrainer):
+    """SentenceRETrainer adapted for combined-encoder experiments.
+
+    Overrides three methods from the parent:
+
+    * ``__init__`` — creates :class:`DataLoader` instances with
+      :func:`combine_collate_fn` instead of RELoader, skipping the tokenizer
+      requirement embedded in :class:`~deepref.dataset.re_dataset.RELoader`.
+    * ``iterate_loader`` — handles ``dict`` batches ``{"labels": …, "items": …}``
+      and moves only tensor data to the target device (the ``items`` list stays
+      on CPU since encoder internals handle device placement).
+    * ``eval_model`` — computes precision / recall / F1 directly with sklearn
+      instead of delegating to ``REDataset.eval``, which cannot operate on a
+      :class:`~torch.utils.data.Subset`.
+    * ``train_model`` — adds per-epoch MLflow metric logging on top of the
+      standard checkpointing logic.
+    """
+
+    def __init__(
+        self,
+        model: SoftmaxMLP,
+        train_dataset: Subset,
+        test_dataset: Subset,
+        ckpt: str,
+        training_parameters: dict[str, Any],
+    ) -> None:
+        # Initialise nn.Module directly — we rebuild everything that
+        # SentenceRETrainer.__init__ does but use our custom DataLoader.
+        nn.Module.__init__(self)
+
+        self.model = model
+        self.training_parameters = training_parameters
+        self.max_epoch = training_parameters["max_epoch"]
+        self.criterion = training_parameters["criterion"]
+        self.lr = training_parameters["lr"]
+        batch_size = training_parameters["batch_size"]
+
+        self.train_loader = DataLoader(
+            train_dataset,
+            batch_size=batch_size,
+            shuffle=True,
+            collate_fn=combine_collate_fn,
+        )
+        self.test_loader = DataLoader(
+            test_dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            collate_fn=combine_collate_fn,
+        )
+
+        # Optimizer
+        opt = training_parameters["opt"]
+        lr = training_parameters["lr"]
+        weight_decay = training_parameters.get("weight_decay", 0.0)
+
+        params = self.parameters()
+        if opt == "sgd":
+            self.optimizer = optim.SGD(params, lr, weight_decay=weight_decay)
+        elif opt == "adam":
+            self.optimizer = optim.Adam(params, lr, weight_decay=weight_decay)
+        elif opt == "adamw":
+            from torch.optim import AdamW
+            named = list(self.named_parameters())
+            no_decay = ["bias", "LayerNorm.bias", "LayerNorm.weight"]
+            grouped = [
+                {
+                    "params": [p for n, p in named if not any(nd in n for nd in no_decay)],
+                    "weight_decay": 0.01,
+                    "lr": lr,
+                },
+                {
+                    "params": [p for n, p in named if any(nd in n for nd in no_decay)],
+                    "weight_decay": 0.0,
+                    "lr": lr,
+                },
+            ]
+            self.optimizer = AdamW(grouped)
+        else:
+            raise ValueError(f"Invalid optimizer: {opt!r}. Choose sgd, adam, or adamw.")
+
+        # LR scheduler
+        warmup_step = training_parameters.get("warmup_step", 0)
+        if warmup_step > 0:
+            from transformers import get_linear_schedule_with_warmup
+            training_steps = len(train_dataset) // batch_size * self.max_epoch
+            self.scheduler = get_linear_schedule_with_warmup(
+                self.optimizer,
+                num_warmup_steps=warmup_step,
+                num_training_steps=training_steps,
+            )
+        else:
+            self.scheduler = None
+
+        if torch.cuda.is_available():
+            self.cuda()
+
+        self.ckpt = ckpt
+
+    # ------------------------------------------------------------------
+    # Core loop
+    # ------------------------------------------------------------------
+
+    def iterate_loader(
+        self,
+        loader: DataLoader,
+        warmup: bool = True,
+        global_step: int = 0,
+        training: bool = True,
+    ) -> float | None:
+        """One pass through *loader* with dict-format ``{"labels", "items"}`` batches.
+
+        Only tensor fields (``"labels"``) are moved to the model's device;
+        the ``"items"`` list is kept as plain Python since each encoder's
+        forward method handles its own device placement.
+
+        Returns:
+            Average training loss when ``training=True``; ``None`` otherwise.
+        """
+        device = next(self.model.parameters()).device
+        avg_loss = AverageMeter()
+        avg_acc = AverageMeter()
+        global_step = 0
+
+        t = tqdm(loader)
+        for data in t:
+            labels = data["labels"].to(device)
+            items = data["items"]
+
+            logits = self.model(items=items)
+            _, pred = logits.max(-1)
+
+            acc = float((pred == labels).long().sum()) / labels.size(0)
+            avg_acc.update(acc, labels.size(0))
+            t.set_postfix(loss=avg_loss.avg, acc=avg_acc.avg)
+
+            if training:
+                loss = self.criterion(logits, labels)
+                avg_loss.update(loss.item(), 1)
+
+                if warmup:
+                    warmup_steps = 300
+                    rate = min(1.0, global_step / warmup_steps) if warmup_steps > 0 else 1.0
+                    for pg in self.optimizer.param_groups:
+                        pg["lr"] = self.lr * rate
+
+                loss.backward()
+                self.optimizer.step()
+                if self.scheduler is not None:
+                    self.scheduler.step()
+                self.optimizer.zero_grad()
+                global_step += 1
+
+        return avg_loss.avg if training else None
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def eval_model(
+        self,
+        eval_loader: DataLoader,
+    ) -> tuple[dict[str, float], list[int], list[int]]:
+        """Evaluate on *eval_loader* and return metrics computed with sklearn.
+
+        Overrides the parent to avoid calling ``loader.dataset.eval(pred_result)``,
+        which does not work on :class:`~torch.utils.data.Subset` objects.
+
+        Returns:
+            ``(result_dict, pred_result, ground_truth)`` matching the
+            signature expected by :meth:`train_model`.
+        """
+        self.eval()
+        pred_result: list[int] = []
+        all_labels: list[int] = []
+        device = next(self.model.parameters()).device
+
+        with torch.no_grad():
+            for data in tqdm(eval_loader):
+                labels = data["labels"].to(device)
+                items = data["items"]
+                logits = self.model(items=items)
+                _, pred = logits.max(-1)
+                pred_result.extend(pred.tolist())
+                all_labels.extend(labels.tolist())
+
+        result = {
+            "acc": accuracy_score(all_labels, pred_result),
+            "micro_p": precision_score(all_labels, pred_result, average="micro", zero_division=0),
+            "micro_r": recall_score(all_labels, pred_result, average="micro", zero_division=0),
+            "micro_f1": f1_score(all_labels, pred_result, average="micro", zero_division=0),
+            "macro_f1": f1_score(all_labels, pred_result, average="macro", zero_division=0),
+        }
+        logger.info("Eval result: %s", result)
+        return result, pred_result, all_labels
+
+    # ------------------------------------------------------------------
+    # Training loop with MLflow logging
+    # ------------------------------------------------------------------
+
+    def train_model(self, warmup: bool = True, metric: str = "micro_f1") -> float:
+        """Train for ``max_epoch`` epochs, log metrics to MLflow per epoch.
+
+        Saves the best checkpoint (by *metric* on the test set) to ``self.ckpt``.
+
+        Returns:
+            Best value of *metric* achieved during training.
+        """
+        best_metric = 0.0
+
+        for epoch in range(self.max_epoch):
+            logger.info("=== Epoch %d / %d — train ===", epoch + 1, self.max_epoch)
+            self.train()
+            self.iterate_loader(self.train_loader, warmup=warmup, training=True)
+
+            logger.info("=== Epoch %d / %d — eval ===", epoch + 1, self.max_epoch)
+            result, _, _ = self.eval_model(self.test_loader)
+
+            logger.info(
+                "Metric %s: current=%.4f  best=%.4f",
+                metric, result[metric], best_metric,
+            )
+            mlflow.log_metrics(
+                {f"val_{k}": v for k, v in result.items() if isinstance(v, float)},
+                step=epoch,
+            )
+
+            if result[metric] > best_metric:
+                logger.info("Best checkpoint — saving to %s", self.ckpt)
+                folder = os.path.dirname(self.ckpt)
+                if folder:
+                    os.makedirs(folder, exist_ok=True)
+                torch.save({"state_dict": self.model.state_dict()}, self.ckpt)
+                best_metric = result[metric]
+
+        logger.info("Best %s on test set: %.4f", metric, best_metric)
+        return best_metric
+
+
+# ---------------------------------------------------------------------------
+# Encoder factory
+# ---------------------------------------------------------------------------
+
+def build_encoder1(cfg: DictConfig, device: str) -> nn.Module:
+    """Instantiate the first encoder from Hydra config."""
+    enc = cfg.encoder1
+    if enc.type == "relation":
+        return RelationEncoder(model_name=enc.model_name, max_length=enc.max_length)
+    if enc.type == "llm":
+        return LLMEncoder(
+            model_name=enc.model_name,
+            max_length=enc.max_length,
+            device=device,
+            trainable=enc.trainable,
+        )
+    raise ValueError(f"Unknown encoder1 type: {enc.type!r}")
+
+
+def build_encoder2(cfg: DictConfig, device: str) -> nn.Module:
+    """Instantiate the second encoder from Hydra config."""
+    enc = cfg.encoder2
+    if enc.type == "bow_sdp":
+        return BoWSDPEncoder()
+    if enc.type == "verbalized_sdp":
+        return VerbalizedSDPEncoder(model_name=enc.model_name, device=device)
+    raise ValueError(f"Unknown encoder2 type: {enc.type!r}")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+@hydra.main(
+    version_base=None,
+    config_path="conf",
+    config_name="combine_experiment",
+)
+def main(cfg: DictConfig) -> None:
+    logger.info("Config:\n%s", OmegaConf.to_yaml(cfg))
+
+    torch.manual_seed(cfg.training.seed)
+    device: str = cfg.device
+
+    # ── MLflow ──────────────────────────────────────────────────────────────
+    if cfg.mlflow.tracking_uri:
+        mlflow.set_tracking_uri(cfg.mlflow.tracking_uri)
+    mlflow.set_experiment(cfg.mlflow.experiment_name)
+
+    run_name = (
+        f"{cfg.dataset.name}"
+        f"__{cfg.encoder1.type}"
+        f"__{cfg.encoder2.type}"
+    )
+
+    with mlflow.start_run(run_name=run_name):
+        mlflow.log_params({
+            "dataset": cfg.dataset.name,
+            "encoder1_type": cfg.encoder1.type,
+            "encoder1_model": cfg.encoder1.get("model_name", "n/a"),
+            "encoder2_type": cfg.encoder2.type,
+            "encoder2_model": cfg.encoder2.get("model_name", "n/a"),
+            "batch_size": cfg.training.batch_size,
+            "lr": cfg.training.lr,
+            "max_epoch": cfg.training.max_epoch,
+            "num_mlp_layers": cfg.training.num_mlp_layers,
+            "dropout": cfg.training.dropout,
+            "opt": cfg.training.opt,
+            "train_ratio": cfg.training.train_ratio,
+            "seed": cfg.training.seed,
+        })
+
+        try:
+            # ── Dataset ─────────────────────────────────────────────────────
+            csv_path = Path(cfg.dataset.csv_path)
+            if not csv_path.is_absolute():
+                csv_path = Path(hydra.utils.get_original_cwd()) / csv_path
+
+            dataset = CombineREDataset(str(csv_path))
+            num_class = len(dataset.rel2id)
+            logger.info(
+                "Loaded '%s': %d samples, %d classes",
+                cfg.dataset.name, len(dataset), num_class,
+            )
+
+            train_subset, test_subset = make_split_subsets(
+                dataset,
+                train_ratio=cfg.training.train_ratio,
+                seed=cfg.training.seed,
+            )
+
+            # ── Encoders ────────────────────────────────────────────────────
+            logger.info("Building encoder1 (%s) …", cfg.encoder1.type)
+            encoder1 = build_encoder1(cfg, device)
+
+            logger.info("Building encoder2 (%s) …", cfg.encoder2.type)
+            encoder2 = build_encoder2(cfg, device)
+
+            combine = CombineEmbeddings(encoder1, encoder2)
+
+            # ── Model ───────────────────────────────────────────────────────
+            model = SoftmaxMLP(
+                sentence_encoder=combine,
+                num_class=num_class,
+                rel2id=dataset.rel2id,
+                dropout=cfg.training.dropout,
+                num_layers=cfg.training.num_mlp_layers,
+            )
+
+            # ── Trainer ─────────────────────────────────────────────────────
+            ckpt_path = os.path.join(
+                hydra.utils.get_original_cwd(),
+                "ckpt",
+                f"{cfg.dataset.name}_{cfg.encoder1.type}_{cfg.encoder2.type}.pth.tar",
+            )
+
+            training_parameters = {
+                "max_epoch": cfg.training.max_epoch,
+                "criterion": nn.CrossEntropyLoss(),
+                "lr": cfg.training.lr,
+                "batch_size": cfg.training.batch_size,
+                "opt": cfg.training.opt,
+                "weight_decay": cfg.training.get("weight_decay", 0.0),
+                "warmup_step": cfg.training.get("warmup_step", 0),
+            }
+
+            trainer = CombineRETrainer(
+                model=model,
+                train_dataset=train_subset,
+                test_dataset=test_subset,
+                ckpt=ckpt_path,
+                training_parameters=training_parameters,
+            )
+
+            # ── Training ────────────────────────────────────────────────────
+            best_micro_f1 = trainer.train_model(metric="micro_f1")
+
+            mlflow.log_metric("best_micro_f1", best_micro_f1)
+            mlflow.set_tag("status", "success")
+
+            logger.info("Run '%s' finished — best micro_f1: %.4f", run_name, best_micro_f1)
+
+        except Exception:
+            import traceback
+            logger.error("Run '%s' failed:\n%s", run_name, traceback.format_exc())
+            mlflow.set_tag("status", "failed")
+            raise
+
+
+if __name__ == "__main__":
+    main()

--- a/deepref/tests/experiments/test_combine_embeddings_experiments.py
+++ b/deepref/tests/experiments/test_combine_embeddings_experiments.py
@@ -1,0 +1,725 @@
+"""
+Tests for the combine-embeddings experiment classes:
+
+    * CombineREDataset   — raw-item dataset backed by REDataset CSV loading.
+    * combine_collate_fn — batch collation compatible with SentenceRETrainer.
+    * CombineEmbeddings  — dual-encoder concatenation wrapper.
+    * CombineRETrainer   — SentenceRETrainer subclass with custom loaders and
+                           sklearn-based evaluation.
+
+Test strategy
+-------------
+* CombineREDataset: tested against benchmark/semeval2010.csv (real file,
+  DataFrame sliced to 10 rows so tests run in milliseconds).
+* CombineEmbeddings._get_hidden_size / _encode_single: encoder-type dispatch
+  verified with lightweight mocks — no LLM download required.
+* CombineEmbeddings.forward: tested end-to-end with two BoWSDPEncoder
+  instances (spaCy only, no LLM).
+* CombineRETrainer: tested end-to-end with two BoWSDPEncoder instances.
+  train_model has mlflow patched out; eval_model runs real forward passes on
+  4 samples to keep wall-time low.
+* Integration tests that would require a real LLM are marked
+  ``@pytest.mark.integration``.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest import mock
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Subset
+
+from deepref.experiments.run_combine_embeddings_experiments import (
+    CombineEmbeddings,
+    CombineREDataset,
+    CombineRETrainer,
+    combine_collate_fn,
+    make_split_subsets,
+)
+from deepref.framework.sentence_re_trainer import SentenceRETrainer
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+CSV_PATH = "benchmark/semeval2010.csv"
+
+# Item dict format used by all encoders
+ITEM_SIMPLE = {
+    "token": ["The", "audits", "were", "about", "waste", "."],
+    "h": {"name": "audits", "pos": [1, 2]},
+    "t": {"name": "waste", "pos": [4, 5]},
+}
+
+# Hidden size used by mocked LLM / Relation encoders
+MOCK_HIDDEN = 64
+
+# Number of rows kept in the sliced dataset fixture
+SLICE_SIZE = 10
+
+# Indices used for tiny train / test subsets inside the trainer fixture
+_TRAIN_IDX = list(range(4))
+_TEST_IDX = list(range(4, 8))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def dataset():
+    """10-row slice of semeval2010 for fast tests (no tokenizer required)."""
+    ds = CombineREDataset(CSV_PATH)
+    ds.df = ds.df.iloc[:SLICE_SIZE].reset_index(drop=True)
+    return ds
+
+
+@pytest.fixture(scope="module")
+def bow_encoder():
+    """Real BoWSDPEncoder — loads spaCy once; no LLM download."""
+    from deepref.encoder.sdp_encoder import BoWSDPEncoder
+    return BoWSDPEncoder()
+
+
+def _make_mock_model(hidden_size: int) -> MagicMock:
+    """Return a MagicMock that behaves like a HuggingFace model.
+
+    Crucially, ``.to(device)`` returns *the same object* so that
+    ``LLMEncoder.__init__`` (which does ``AutoModel.from_pretrained(...).to(device)``)
+    ends up with a mock whose ``config.hidden_size`` is still set correctly.
+    """
+    mock_model = MagicMock()
+    mock_model.config.hidden_size = hidden_size
+    mock_model.to.return_value = mock_model          # .to(device) → self
+    mock_model.parameters.return_value = iter([torch.zeros(1)])
+    return mock_model
+
+
+@pytest.fixture(scope="module")
+def mock_llm_encoder():
+    """LLMEncoder instantiated with patched AutoModel / AutoTokenizer."""
+    from deepref.encoder.llm_encoder import LLMEncoder
+    mock_model = _make_mock_model(MOCK_HIDDEN)
+    mock_tokenizer = MagicMock()
+    with (
+        patch("deepref.encoder.llm_encoder.AutoModel.from_pretrained", return_value=mock_model),
+        patch("deepref.encoder.llm_encoder.AutoTokenizer.from_pretrained", return_value=mock_tokenizer),
+    ):
+        enc = LLMEncoder("mock-llm")
+    return enc
+
+
+@pytest.fixture(scope="module")
+def mock_relation_encoder():
+    """RelationEncoder instantiated with patched transformer internals."""
+    from deepref.encoder.relation_encoder import RelationEncoder
+    mock_model = _make_mock_model(MOCK_HIDDEN)
+    mock_tokenizer = MagicMock()
+    mock_tokenizer.mask_token = "[MASK]"
+    mock_tokenizer.cls_token = "[CLS]"
+    mock_tokenizer.sep_token = "[SEP]"
+    mock_tokenizer.pad_token_id = 0
+    with (
+        patch("deepref.encoder.llm_encoder.AutoModel.from_pretrained", return_value=mock_model),
+        patch("deepref.encoder.llm_encoder.AutoTokenizer.from_pretrained", return_value=mock_tokenizer),
+    ):
+        enc = RelationEncoder("mock-relation", max_length=16)
+    return enc
+
+
+@pytest.fixture(scope="module")
+def mock_verbalized_encoder():
+    """VerbalizedSDPEncoder with patched LLM backbone."""
+    from deepref.encoder.sdp_encoder import VerbalizedSDPEncoder
+    mock_model = _make_mock_model(MOCK_HIDDEN)
+    mock_tokenizer = MagicMock()
+    with (
+        patch("deepref.encoder.llm_encoder.AutoModel.from_pretrained", return_value=mock_model),
+        patch("deepref.encoder.llm_encoder.AutoTokenizer.from_pretrained", return_value=mock_tokenizer),
+    ):
+        enc = VerbalizedSDPEncoder("mock-verbalized")
+    return enc
+
+
+@pytest.fixture(scope="module")
+def combine_bow_bow(bow_encoder):
+    """CombineEmbeddings wrapping the same BoWSDPEncoder twice (no LLM)."""
+    return CombineEmbeddings(bow_encoder, bow_encoder)
+
+
+@pytest.fixture
+def trainer(dataset, bow_encoder):
+    """Fresh CombineRETrainer per test — prevents state leaking between tests."""
+    from deepref.model.softmax_mlp import SoftmaxMLP
+
+    combine = CombineEmbeddings(bow_encoder, bow_encoder)
+    num_class = len(dataset.rel2id)
+    model = SoftmaxMLP(
+        sentence_encoder=combine,
+        num_class=num_class,
+        rel2id=dataset.rel2id,
+        num_layers=2,
+    )
+
+    training_params = {
+        "max_epoch": 1,
+        "criterion": nn.CrossEntropyLoss(),
+        "lr": 1e-3,
+        "batch_size": 2,
+        "opt": "adam",
+        "weight_decay": 0.0,
+        "warmup_step": 0,
+    }
+    ckpt = "/tmp/test_combine_re_trainer.pth.tar"
+
+    return CombineRETrainer(
+        model=model,
+        train_dataset=Subset(dataset, _TRAIN_IDX),
+        test_dataset=Subset(dataset, _TEST_IDX),
+        ckpt=ckpt,
+        training_parameters=training_params,
+    ), ckpt
+
+
+# ===========================================================================
+# 1. CombineREDataset
+# ===========================================================================
+
+class TestCombineREDataset:
+
+    def test_len_equals_sliced_rows(self, dataset):
+        assert len(dataset) == SLICE_SIZE
+
+    def test_rel2id_is_not_empty(self, dataset):
+        assert len(dataset.rel2id) > 0
+
+    def test_rel2id_keys_are_strings(self, dataset):
+        for key in dataset.rel2id:
+            assert isinstance(key, str)
+
+    def test_rel2id_values_are_integers(self, dataset):
+        for val in dataset.rel2id.values():
+            assert isinstance(val, int)
+
+    def test_rel2id_values_are_unique(self, dataset):
+        values = list(dataset.rel2id.values())
+        assert len(values) == len(set(values))
+
+    def test_getitem_returns_tuple_of_two(self, dataset):
+        result = dataset[0]
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+    def test_getitem_item_is_dict(self, dataset):
+        item, _ = dataset[0]
+        assert isinstance(item, dict)
+
+    def test_getitem_item_has_token_key(self, dataset):
+        item, _ = dataset[0]
+        assert "token" in item
+
+    def test_getitem_item_has_h_key(self, dataset):
+        item, _ = dataset[0]
+        assert "h" in item
+
+    def test_getitem_item_has_t_key(self, dataset):
+        item, _ = dataset[0]
+        assert "t" in item
+
+    def test_getitem_token_is_list(self, dataset):
+        item, _ = dataset[0]
+        assert isinstance(item["token"], list)
+
+    def test_getitem_token_elements_are_strings(self, dataset):
+        item, _ = dataset[0]
+        for tok in item["token"]:
+            assert isinstance(tok, str)
+
+    def test_getitem_h_has_name_key(self, dataset):
+        item, _ = dataset[0]
+        assert "name" in item["h"]
+
+    def test_getitem_h_has_pos_key(self, dataset):
+        item, _ = dataset[0]
+        assert "pos" in item["h"]
+
+    def test_getitem_t_has_name_key(self, dataset):
+        item, _ = dataset[0]
+        assert "name" in item["t"]
+
+    def test_getitem_t_has_pos_key(self, dataset):
+        item, _ = dataset[0]
+        assert "pos" in item["t"]
+
+    def test_getitem_pos_is_list_of_two_ints(self, dataset):
+        item, _ = dataset[0]
+        for entity in (item["h"], item["t"]):
+            pos = entity["pos"]
+            assert isinstance(pos, list)
+            assert len(pos) == 2
+            assert all(isinstance(p, int) for p in pos)
+
+    def test_getitem_label_is_tensor(self, dataset):
+        _, label = dataset[0]
+        assert isinstance(label, torch.Tensor)
+
+    def test_getitem_label_dtype_is_long(self, dataset):
+        _, label = dataset[0]
+        assert label.dtype == torch.long
+
+    def test_getitem_label_is_valid_class_id(self, dataset):
+        _, label = dataset[0]
+        assert 0 <= label.item() < len(dataset.rel2id)
+
+    def test_getitem_entity_name_consistent_with_tokens(self, dataset):
+        """Entity name should be the concatenation of tokens at the given pos."""
+        item, _ = dataset[0]
+        for entity_key in ("h", "t"):
+            ent = item[entity_key]
+            start, end = ent["pos"]
+            expected_name = " ".join(item["token"][start:end])
+            assert ent["name"] == expected_name
+
+    def test_missing_csv_returns_zero_length(self):
+        ds = CombineREDataset("nonexistent_path/fake.csv")
+        assert len(ds) == 0
+
+
+# ===========================================================================
+# 2. combine_collate_fn
+# ===========================================================================
+
+class TestCombineCollate:
+
+    @pytest.fixture(autouse=True)
+    def _batch(self, dataset):
+        item0, label0 = dataset[0]
+        item1, label1 = dataset[1]
+        self.batch_output = combine_collate_fn([(item0, label0), (item1, label1)])
+        self.batch_size = 2
+
+    def test_returns_dict(self):
+        assert isinstance(self.batch_output, dict)
+
+    def test_has_labels_key(self):
+        assert "labels" in self.batch_output
+
+    def test_has_items_key(self):
+        assert "items" in self.batch_output
+
+    def test_labels_is_tensor(self):
+        assert isinstance(self.batch_output["labels"], torch.Tensor)
+
+    def test_labels_dtype_is_long(self):
+        assert self.batch_output["labels"].dtype == torch.long
+
+    def test_labels_shape_equals_batch_size(self):
+        assert self.batch_output["labels"].shape == (self.batch_size,)
+
+    def test_items_is_list(self):
+        assert isinstance(self.batch_output["items"], list)
+
+    def test_items_length_equals_batch_size(self):
+        assert len(self.batch_output["items"]) == self.batch_size
+
+    def test_items_elements_are_dicts(self):
+        for it in self.batch_output["items"]:
+            assert isinstance(it, dict)
+
+
+# ===========================================================================
+# 3. CombineEmbeddings — hidden-size helpers
+# ===========================================================================
+
+class TestCombineEmbeddingsHiddenSize:
+
+    def test_bow_hidden_size_equals_dep_vocab_len(self, bow_encoder):
+        size = CombineEmbeddings._get_hidden_size(bow_encoder)
+        assert size == len(bow_encoder.dep_vocab)
+
+    def test_relation_encoder_hidden_size_equals_encoder_attribute(
+        self, mock_relation_encoder
+    ):
+        size = CombineEmbeddings._get_hidden_size(mock_relation_encoder)
+        assert size == mock_relation_encoder.hidden_size
+
+    def test_llm_encoder_hidden_size_equals_model_config(self, mock_llm_encoder):
+        size = CombineEmbeddings._get_hidden_size(mock_llm_encoder)
+        assert size == MOCK_HIDDEN
+
+    def test_verbalized_sdp_hidden_size_equals_model_config(
+        self, mock_verbalized_encoder
+    ):
+        size = CombineEmbeddings._get_hidden_size(mock_verbalized_encoder)
+        assert size == MOCK_HIDDEN
+
+    def test_model_config_hidden_size_is_sum_of_both(self, bow_encoder):
+        h = len(bow_encoder.dep_vocab)
+        combine = CombineEmbeddings(bow_encoder, bow_encoder)
+        assert combine.model.config.hidden_size == h + h
+
+    def test_unknown_encoder_raises_value_error(self):
+        class _Unknown(nn.Module):
+            pass
+        with pytest.raises(ValueError, match="Cannot determine hidden size"):
+            CombineEmbeddings._get_hidden_size(_Unknown())
+
+
+# ===========================================================================
+# 4. CombineEmbeddings — _encode_single dispatch
+# ===========================================================================
+
+class TestCombineEmbeddingsEncodeSingle:
+    """
+    Verify that _encode_single dispatches correctly to each encoder type and
+    always returns a 1-D float32 tensor of the expected length.
+    Transformer forward passes are replaced by lightweight mocks so no LLM
+    download is required for these tests.
+    """
+
+    # ── BoWSDPEncoder ────────────────────────────────────────────────────────
+
+    def test_bow_returns_tensor(self, bow_encoder):
+        result = CombineEmbeddings._encode_single(bow_encoder, ITEM_SIMPLE)
+        assert isinstance(result, torch.Tensor)
+
+    def test_bow_is_1d(self, bow_encoder):
+        result = CombineEmbeddings._encode_single(bow_encoder, ITEM_SIMPLE)
+        assert result.ndim == 1
+
+    def test_bow_is_float32(self, bow_encoder):
+        result = CombineEmbeddings._encode_single(bow_encoder, ITEM_SIMPLE)
+        assert result.dtype == torch.float32
+
+    def test_bow_length_equals_dep_vocab(self, bow_encoder):
+        result = CombineEmbeddings._encode_single(bow_encoder, ITEM_SIMPLE)
+        assert result.shape[0] == len(bow_encoder.dep_vocab)
+
+    # ── RelationEncoder ──────────────────────────────────────────────────────
+
+    def test_relation_encoder_is_1d(self, mock_relation_encoder):
+        fake_tok = (
+            torch.zeros(1, 16, dtype=torch.long),
+            torch.ones(1, 16, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+        )
+        fake_emb = torch.zeros(1, MOCK_HIDDEN * 3)
+        with (
+            mock.patch.object(mock_relation_encoder, "tokenize", return_value=fake_tok),
+            mock.patch.object(mock_relation_encoder, "forward", return_value=fake_emb),
+        ):
+            result = CombineEmbeddings._encode_single(mock_relation_encoder, ITEM_SIMPLE)
+        assert result.ndim == 1
+
+    def test_relation_encoder_length_is_3h(self, mock_relation_encoder):
+        fake_tok = (
+            torch.zeros(1, 16, dtype=torch.long),
+            torch.ones(1, 16, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+        )
+        fake_emb = torch.zeros(1, MOCK_HIDDEN * 3)
+        with (
+            mock.patch.object(mock_relation_encoder, "tokenize", return_value=fake_tok),
+            mock.patch.object(mock_relation_encoder, "forward", return_value=fake_emb),
+        ):
+            result = CombineEmbeddings._encode_single(mock_relation_encoder, ITEM_SIMPLE)
+        assert result.shape[0] == MOCK_HIDDEN * 3
+
+    def test_relation_encoder_is_float32(self, mock_relation_encoder):
+        fake_tok = (
+            torch.zeros(1, 16, dtype=torch.long),
+            torch.ones(1, 16, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+            torch.zeros(1, 1, dtype=torch.long),
+        )
+        fake_emb = torch.zeros(1, MOCK_HIDDEN * 3, dtype=torch.float16)
+        with (
+            mock.patch.object(mock_relation_encoder, "tokenize", return_value=fake_tok),
+            mock.patch.object(mock_relation_encoder, "forward", return_value=fake_emb),
+        ):
+            result = CombineEmbeddings._encode_single(mock_relation_encoder, ITEM_SIMPLE)
+        assert result.dtype == torch.float32
+
+    # ── LLMEncoder ───────────────────────────────────────────────────────────
+
+    def test_llm_encoder_is_1d(self, mock_llm_encoder):
+        fake_emb = torch.zeros(1, MOCK_HIDDEN)
+        with mock.patch.object(mock_llm_encoder, "forward", return_value=fake_emb):
+            result = CombineEmbeddings._encode_single(mock_llm_encoder, ITEM_SIMPLE)
+        assert result.ndim == 1
+
+    def test_llm_encoder_length_equals_hidden(self, mock_llm_encoder):
+        fake_emb = torch.zeros(1, MOCK_HIDDEN)
+        with mock.patch.object(mock_llm_encoder, "forward", return_value=fake_emb):
+            result = CombineEmbeddings._encode_single(mock_llm_encoder, ITEM_SIMPLE)
+        assert result.shape[0] == MOCK_HIDDEN
+
+    def test_llm_encoder_encodes_joined_token_text(self, mock_llm_encoder):
+        """LLMEncoder path should join tokens into a string before encoding."""
+        fake_emb = torch.zeros(1, MOCK_HIDDEN)
+        with mock.patch.object(mock_llm_encoder, "forward", return_value=fake_emb) as mock_fwd:
+            CombineEmbeddings._encode_single(mock_llm_encoder, ITEM_SIMPLE)
+        called_text = mock_fwd.call_args[0][0]
+        assert called_text == " ".join(ITEM_SIMPLE["token"])
+
+    # ── VerbalizedSDPEncoder ─────────────────────────────────────────────────
+
+    def test_verbalized_sdp_is_1d(self, mock_verbalized_encoder):
+        fake_emb = torch.zeros(1, MOCK_HIDDEN)
+        with mock.patch.object(mock_verbalized_encoder, "forward", return_value=fake_emb):
+            result = CombineEmbeddings._encode_single(mock_verbalized_encoder, ITEM_SIMPLE)
+        assert result.ndim == 1
+
+    def test_verbalized_sdp_length_equals_hidden(self, mock_verbalized_encoder):
+        fake_emb = torch.zeros(1, MOCK_HIDDEN)
+        with mock.patch.object(mock_verbalized_encoder, "forward", return_value=fake_emb):
+            result = CombineEmbeddings._encode_single(mock_verbalized_encoder, ITEM_SIMPLE)
+        assert result.shape[0] == MOCK_HIDDEN
+
+    def test_verbalized_sdp_called_with_item_dict(self, mock_verbalized_encoder):
+        """VerbalizedSDPEncoder path passes the raw item dict to forward."""
+        fake_emb = torch.zeros(1, MOCK_HIDDEN)
+        with mock.patch.object(mock_verbalized_encoder, "forward", return_value=fake_emb) as mock_fwd:
+            CombineEmbeddings._encode_single(mock_verbalized_encoder, ITEM_SIMPLE)
+        mock_fwd.assert_called_once_with(ITEM_SIMPLE)
+
+
+# ===========================================================================
+# 5. CombineEmbeddings — forward
+# ===========================================================================
+
+class TestCombineEmbeddingsForward:
+    """
+    End-to-end forward tests using two real BoWSDPEncoder instances.
+    No LLM download required.
+    """
+
+    def test_returns_tensor(self, combine_bow_bow):
+        result = combine_bow_bow([ITEM_SIMPLE])
+        assert isinstance(result, torch.Tensor)
+
+    def test_dtype_is_float32(self, combine_bow_bow):
+        result = combine_bow_bow([ITEM_SIMPLE])
+        assert result.dtype == torch.float32
+
+    def test_ndim_is_2(self, combine_bow_bow):
+        result = combine_bow_bow([ITEM_SIMPLE])
+        assert result.ndim == 2
+
+    def test_single_item_batch_dim_is_1(self, combine_bow_bow):
+        result = combine_bow_bow([ITEM_SIMPLE])
+        assert result.shape[0] == 1
+
+    def test_batch_size_matches_input_list_length(self, combine_bow_bow):
+        batch = [ITEM_SIMPLE, ITEM_SIMPLE]
+        result = combine_bow_bow(batch)
+        assert result.shape[0] == len(batch)
+
+    def test_embedding_dim_equals_combined_hidden(self, bow_encoder, combine_bow_bow):
+        expected_dim = combine_bow_bow.model.config.hidden_size
+        result = combine_bow_bow([ITEM_SIMPLE])
+        assert result.shape[1] == expected_dim
+
+    def test_forward_callable_with_items_kwarg(self, combine_bow_bow):
+        """SoftmaxMLP calls the encoder as encoder(**args) where args={'items': …}."""
+        result = combine_bow_bow(items=[ITEM_SIMPLE])
+        assert result.shape[0] == 1
+
+
+# ===========================================================================
+# 6. CombineRETrainer — initialisation
+# ===========================================================================
+
+class TestCombineRETrainerInit:
+
+    def test_is_instance_of_sentence_re_trainer(self, trainer):
+        t, _ = trainer
+        assert isinstance(t, SentenceRETrainer)
+
+    def test_has_train_loader(self, trainer):
+        t, _ = trainer
+        assert hasattr(t, "train_loader")
+
+    def test_train_loader_is_dataloader(self, trainer):
+        t, _ = trainer
+        assert isinstance(t.train_loader, DataLoader)
+
+    def test_has_test_loader(self, trainer):
+        t, _ = trainer
+        assert hasattr(t, "test_loader")
+
+    def test_test_loader_is_dataloader(self, trainer):
+        t, _ = trainer
+        assert isinstance(t.test_loader, DataLoader)
+
+    def test_has_optimizer(self, trainer):
+        t, _ = trainer
+        assert hasattr(t, "optimizer")
+
+    def test_train_loader_uses_combine_collate(self, trainer):
+        """Batches from the train loader must have 'labels' and 'items' keys."""
+        t, _ = trainer
+        batch = next(iter(t.train_loader))
+        assert isinstance(batch, dict)
+        assert "labels" in batch
+        assert "items" in batch
+
+    def test_test_loader_uses_combine_collate(self, trainer):
+        t, _ = trainer
+        batch = next(iter(t.test_loader))
+        assert isinstance(batch, dict)
+        assert "labels" in batch
+        assert "items" in batch
+
+
+# ===========================================================================
+# 7. CombineRETrainer — eval_model
+# ===========================================================================
+
+class TestCombineRETrainerEvalModel:
+
+    def test_returns_tuple_of_three(self, trainer):
+        t, _ = trainer
+        result = t.eval_model(t.test_loader)
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+
+    def test_first_element_is_dict(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert isinstance(result_dict, dict)
+
+    def test_result_has_acc(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert "acc" in result_dict
+
+    def test_result_has_micro_f1(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert "micro_f1" in result_dict
+
+    def test_result_has_macro_f1(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert "macro_f1" in result_dict
+
+    def test_result_has_micro_p(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert "micro_p" in result_dict
+
+    def test_result_has_micro_r(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert "micro_r" in result_dict
+
+    def test_acc_is_between_0_and_1(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert 0.0 <= result_dict["acc"] <= 1.0
+
+    def test_micro_f1_is_between_0_and_1(self, trainer):
+        t, _ = trainer
+        result_dict, _, _ = t.eval_model(t.test_loader)
+        assert 0.0 <= result_dict["micro_f1"] <= 1.0
+
+    def test_predictions_length_matches_test_size(self, trainer):
+        t, _ = trainer
+        _, preds, _ = t.eval_model(t.test_loader)
+        assert len(preds) == len(_TEST_IDX)
+
+    def test_labels_length_matches_test_size(self, trainer):
+        t, _ = trainer
+        _, _, labels = t.eval_model(t.test_loader)
+        assert len(labels) == len(_TEST_IDX)
+
+    def test_predictions_are_valid_class_ids(self, trainer, dataset):
+        t, _ = trainer
+        num_class = len(dataset.rel2id)
+        _, preds, _ = t.eval_model(t.test_loader)
+        for p in preds:
+            assert 0 <= p < num_class
+
+
+# ===========================================================================
+# 8. CombineRETrainer — iterate_loader
+# ===========================================================================
+
+class TestCombineRETrainerIterateLoader:
+
+    def test_training_returns_float(self, trainer):
+        t, _ = trainer
+        loss = t.iterate_loader(t.train_loader, training=True)
+        assert isinstance(loss, float)
+
+    def test_training_loss_is_non_negative(self, trainer):
+        t, _ = trainer
+        loss = t.iterate_loader(t.train_loader, training=True)
+        assert loss >= 0.0
+
+    def test_inference_returns_none(self, trainer):
+        t, _ = trainer
+        result = t.iterate_loader(t.test_loader, training=False)
+        assert result is None
+
+
+# ===========================================================================
+# 9. CombineRETrainer — train_model
+# ===========================================================================
+
+class TestCombineRETrainerTrainModel:
+
+    def test_returns_float(self, trainer):
+        t, _ = trainer
+        with patch("mlflow.log_metrics"):
+            best = t.train_model(metric="micro_f1")
+        assert isinstance(best, float)
+
+    def test_best_metric_is_non_negative(self, trainer):
+        t, _ = trainer
+        with patch("mlflow.log_metrics"):
+            best = t.train_model(metric="micro_f1")
+        assert best >= 0.0
+
+    def test_saves_checkpoint_when_metric_improves(self, trainer):
+        t, ckpt = trainer
+        # Force eval_model to return a clearly positive metric so the
+        # checkpoint is guaranteed to be written on the first epoch.
+        good_result = {
+            "acc": 1.0,
+            "micro_f1": 1.0,
+            "macro_f1": 1.0,
+            "micro_p": 1.0,
+            "micro_r": 1.0,
+        }
+        with (
+            patch("mlflow.log_metrics"),
+            mock.patch.object(t, "eval_model", return_value=(good_result, [], [])),
+        ):
+            t.train_model(metric="micro_f1")
+        assert os.path.exists(ckpt)
+
+    def test_mlflow_log_metrics_called_per_epoch(self, trainer):
+        t, _ = trainer
+        good_result = {
+            "acc": 0.9, "micro_f1": 0.8, "macro_f1": 0.7,
+            "micro_p": 0.8, "micro_r": 0.8,
+        }
+        with (
+            patch("mlflow.log_metrics") as mock_log,
+            mock.patch.object(t, "eval_model", return_value=(good_result, [], [])),
+        ):
+            t.train_model(metric="micro_f1")
+        # Called once per epoch (max_epoch=1 in the trainer fixture)
+        assert mock_log.call_count == t.max_epoch

--- a/deepref/tests/experiments/test_combine_embeddings_experiments.py
+++ b/deepref/tests/experiments/test_combine_embeddings_experiments.py
@@ -39,7 +39,7 @@ from deepref.experiments.run_combine_embeddings_experiments import (
     CombineREDataset,
     CombineRETrainer,
     combine_collate_fn,
-    make_split_subsets,
+    load_split_datasets,
 )
 from deepref.framework.sentence_re_trainer import SentenceRETrainer
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
+dependencies = [
+    "hydra-core>=1.3.2",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,90 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.9.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/38/7859ff46355f76f8d19459005ca000b6e7012f2f1ca597746cbcd1fbfe5e/antlr4-python3-runtime-4.9.3.tar.gz", hash = "sha256:f224469b4168294902bb1efa80a8bf7855f24c99aef99cbefc1bcd3cce77881b", size = 117034, upload-time = "2021-11-06T17:52:23.524Z" }
+
+[[package]]
 name = "deepref"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "hydra-core" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "hydra-core", specifier = ">=1.3.2" }]
+
+[[package]]
+name = "hydra-core"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/50/e0edd38dcd63fb26a8547f13d28f7a008bc4a3fd4eb4ff030673f22ad41a/hydra_core-1.3.2-py3-none-any.whl", hash = "sha256:fa0238a9e31df3373b35b0bfb672c34cc92718d21f81311d8996a16de1141d8b", size = 154547, upload-time = "2023-02-23T18:33:40.801Z" },
+]
+
+[[package]]
+name = "omegaconf"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/ee/299d360cdc32edc7d2cf530f3accf79c4fca01e96ffc950d8a52213bd8e4/packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4", size = 143416, upload-time = "2026-01-21T20:50:39.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529", size = 74366, upload-time = "2026-01-21T20:50:37.788Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]


### PR DESCRIPTION
## Summary

- Adds `run_combine_embeddings_experiments.py`: a Hydra + MLflow experiment runner that combines two encoders (e.g. relation BERT + BoW-SDP) via an MLP classifier (`CombineEmbeddings`, `CombineREDataset`, `CombineRETrainer`)
- Refactors `DatasetPreprocessor` to write dataset-native train/test splits (`write_split_csvs`) instead of random percentage splitting; each preprocessor (SemEval2010, DDI, SemEval2018) now reads the original Train/Test file boundaries
- Adds Hydra config hierarchy under `deepref/experiments/conf/` (encoders, datasets, combine experiment)
- Adds `LLMEncoder` and `SentenceEncoder` refactor; removes legacy `PromptEncoder`
- Adds 84 tests covering `CombineREDataset`, `CombineEmbeddings`, `CombineRETrainer`, `DatasetPreprocessor`, preprocessors, encoders, and framework components
- Fixes SemEval2018 download script to use correct test relation files from `gkata/SemEval2018Task7`
- Unifies `rel2id` across train/test splits so class indices are consistent even when label sets differ

## Test plan

- [ ] `pytest deepref/tests/` — all tests pass (non-spaCy/stanza)
- [ ] `bash benchmark/download_semeval2010.sh` → `benchmark/semeval2010_train.csv` + `benchmark/semeval2010_test.csv` generated with 8000/2717 rows
- [ ] `bash benchmark/download_semeval2018.sh` → valid test CSVs (non-NaN relation_type)
- [ ] `python deepref/experiments/run_combine_embeddings_experiments.py` starts training on semeval2010 with 19 classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)