### PR TITLE
Combine-embeddings experiment with early stopping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,10 @@ opennre-egg.info
 # debug
 
 results/
+*.db
 
 *lora/
+
+# Others
+tmp/
+outputs/

--- a/deepref/experiments/conf/combine_experiment.yaml
+++ b/deepref/experiments/conf/combine_experiment.yaml
@@ -18,5 +18,6 @@ training:
   weight_decay: 0.0
   warmup_step: 0
   seed: 42
+  patience: 3
 
 device: cuda

--- a/deepref/experiments/conf/encoder1/llm.yaml
+++ b/deepref/experiments/conf/encoder1/llm.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 encoder1:
   type: llm
-  model_name: HuggingFaceTB/SmolLM-135M-Instruct
+  model_name: Qwen/Qwen3-Embedding-8B
   max_length: 128
   trainable: false
   attn_implementation: sdpa

--- a/deepref/experiments/conf/encoder1/relation.yaml
+++ b/deepref/experiments/conf/encoder1/relation.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 encoder1:
   type: relation
-  model_name: bert-base-uncased
+  model_name: rel-emb-bert-b-uncased
   max_length: 128
   trainable: false

--- a/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
+++ b/deepref/experiments/conf/encoder2/verbalized_sdp.yaml
@@ -1,4 +1,4 @@
 # @package _global_
 encoder2:
   type: verbalized_sdp
-  model_name: HuggingFaceTB/SmolLM-135M-Instruct
+  model_name: Qwen/Qwen3-Embedding-8B

--- a/deepref/framework/early_stopping.py
+++ b/deepref/framework/early_stopping.py
@@ -1,0 +1,28 @@
+class EarlyStopping:
+    """Counter-based early stopping helper.
+
+    Args:
+        patience: Number of epochs without improvement before stopping.
+            ``0`` (default) disables early stopping entirely.
+    """
+
+    def __init__(self, patience: int = 0) -> None:
+        self.patience = patience
+        self._counter = 0
+
+    def step(self, improved: bool) -> bool:
+        """Advance the counter and return ``True`` when training should stop.
+
+        Args:
+            improved: Whether the monitored metric improved this epoch.
+
+        Returns:
+            ``True`` if patience has been exhausted; ``False`` otherwise.
+        """
+        if self.patience == 0:
+            return False
+        if improved:
+            self._counter = 0
+        else:
+            self._counter += 1
+        return self._counter >= self.patience

--- a/deepref/tests/framework/test_sentence_re_trainer.py
+++ b/deepref/tests/framework/test_sentence_re_trainer.py
@@ -1,7 +1,11 @@
 import os
+from unittest import mock
+from unittest.mock import patch
 
 import pytest
+import torch
 from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
 
 from deepref.dataset.re_dataset import REDataset
 from deepref.encoder.sentence_encoder import SentenceEncoder
@@ -24,6 +28,128 @@ def datasets_and_encoder(request):
     test_dataset = REDataset("benchmark/semeval2010", encoder.tokenizer, dataset_split="test")
     test_dataset.df = test_dataset.df[:3]
     return train_dataset, test_dataset, encoder
+
+# ===========================================================================
+# Early stopping — unit tests (no model download; eval_model is mocked)
+# ===========================================================================
+
+def _make_trainer(max_epoch: int, patience: int, ckpt: str = "/tmp/test_es_ckpt.pth.tar"):
+    """Return a minimal SentenceRETrainer with eval_model available to mock.
+
+    Uses a trivial 1-parameter nn.Linear as model to avoid needing a real
+    encoder or dataset download.
+    """
+    # Tiny linear model that satisfies nn.Module interface
+    class _TinyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(2, 2)
+            # Needed by SentenceRETrainer (model.state_dict())
+        def forward(self, **kwargs):
+            return self.linear(torch.zeros(1, 2))
+        def state_dict(self, **kwargs):
+            return self.linear.state_dict()
+
+    tiny_model = _TinyModel()
+
+    # SentenceRETrainer wraps nn.DataParallel; inject model directly
+    training_params = {
+        "max_epoch": max_epoch,
+        "criterion": nn.CrossEntropyLoss(),
+        "lr": 1e-3,
+        "opt": "adam",
+        "weight_decay": 0.0,
+        "warmup_step": 0,
+        "batch_size": 2,
+        "patience": patience,
+    }
+
+    # Bypass __init__ to avoid needing real REDataset / tokenizer
+    trainer = SentenceRETrainer.__new__(SentenceRETrainer)
+    nn.Module.__init__(trainer)
+    trainer.model = tiny_model
+    trainer.parallel_model = nn.DataParallel(tiny_model)
+    trainer.training_parameters = training_params
+    trainer.max_epoch = max_epoch
+    trainer.criterion = training_params["criterion"]
+    trainer.lr = training_params["lr"]
+    trainer.optimizer = torch.optim.Adam(tiny_model.parameters(), lr=1e-3)
+    trainer.scheduler = None
+    trainer.ckpt = ckpt
+    # train_loader / test_loader not needed because iterate_loader is mocked
+    trainer.train_loader = None
+    trainer.test_loader = None
+    return trainer
+
+
+class TestEarlyStopping:
+
+    def test_stops_after_patience_epochs_without_improvement(self):
+        """Training should stop once the stagnation counter hits patience."""
+        patience = 2
+        max_epoch = 10
+        trainer = _make_trainer(max_epoch=max_epoch, patience=patience)
+
+        # eval_model returns 0.5 on epoch 0 (improvement), then stays flat
+        call_count = 0
+        def _fake_eval(loader):
+            nonlocal call_count
+            metric = 0.5 if call_count == 0 else 0.3
+            call_count += 1
+            return ({"acc": metric}, [], [])
+
+        with (
+            mock.patch.object(trainer, "iterate_loader"),
+            mock.patch.object(trainer, "eval_model", side_effect=_fake_eval),
+        ):
+            trainer.train_model(metric="acc")
+
+        # epoch 0 → improve (counter=0)
+        # epoch 1 → stagnate (counter=1)
+        # epoch 2 → stagnate (counter=2 >= patience=2) → stop
+        # So eval_model is called exactly patience+1 times
+        assert call_count == patience + 1
+
+    def test_disabled_when_patience_zero(self):
+        """When patience=0, all max_epoch epochs must be run."""
+        max_epoch = 5
+        trainer = _make_trainer(max_epoch=max_epoch, patience=0)
+
+        call_count = 0
+        def _flat_eval(loader):
+            nonlocal call_count
+            call_count += 1
+            return ({"acc": 0.0}, [], [])
+
+        with (
+            mock.patch.object(trainer, "iterate_loader"),
+            mock.patch.object(trainer, "eval_model", side_effect=_flat_eval),
+        ):
+            trainer.train_model(metric="acc")
+
+        assert call_count == max_epoch
+
+    def test_checkpoint_saved_on_early_stop(self, tmp_path):
+        """Checkpoint must be written before early stopping fires."""
+        ckpt = str(tmp_path / "es_ckpt.pth.tar")
+        trainer = _make_trainer(max_epoch=10, patience=1, ckpt=ckpt)
+
+        # First epoch improves → checkpoint should be saved
+        call_count = 0
+        def _fake_eval(loader):
+            nonlocal call_count
+            metric = 0.8 if call_count == 0 else 0.1
+            call_count += 1
+            return ({"acc": metric}, [], [])
+
+        with (
+            mock.patch.object(trainer, "iterate_loader"),
+            mock.patch.object(trainer, "eval_model", side_effect=_fake_eval),
+        ):
+            trainer.train_model(metric="acc")
+
+        assert os.path.exists(ckpt)
+
 
 def test_trainer_sentence_encoder(datasets_and_encoder):
     train_dataset, test_dataset, encoder = datasets_and_encoder


### PR DESCRIPTION
## Summary

- Adds the **combine-embeddings experiment** runner (`deepref/experiments/run_combine_embeddings_experiments.py`) that trains a `SoftmaxMLP` classifier on top of two concatenated encoders (relation/LLM × BoW-SDP/verbalized-SDP), driven by Hydra multirun and tracked with MLflow.
- Introduces **`EarlyStopping`** (`deepref/framework/early_stopping.py`) and integrates it into both `SentenceRETrainer` and `CombineRETrainer`; `patience=0` disables it.
- Adds `CombineREDataset`, `CombineEmbeddings`, and `CombineRETrainer` with full unit-test coverage; `combine_experiment.yaml` defaults to `patience: 3`.

## Test plan

- [ ] `pytest deepref/tests/framework/test_sentence_re_trainer.py::TestEarlyStopping -v` — early stopping unit tests (mocked, no model download)
- [ ] `pytest deepref/tests/experiments/test_combine_embeddings_experiments.py -v` — combine-embeddings tests including early stopping
- [ ] Smoke-run: `python deepref/experiments/run_combine_embeddings_experiments.py training.patience=1 training.max_epoch=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)