### PR TITLE
Use ModelRegistry in VerbalizedSDPEncoder.forward()

### DIFF
--- a/deepref/encoder/sdp_encoder.py
+++ b/deepref/encoder/sdp_encoder.py
@@ -456,10 +456,12 @@ class VerbalizedSDPEncoder(SDPEncoder, LLMEncoder):
         Returns:
             Float32 tensor of shape ``(1, hidden_dim)``, L2-normalised.
         """
-        device = next(self.model.parameters()).device
         batch = self.tokenize(item)
-        batch = {k: v.to(device) for k, v in batch.items()}
-        model_outputs = self.model(**batch)
+        model_outputs = self.registry.run_from_input_ids(
+            self.model_name,
+            batch['input_ids'],
+            batch['attention_mask'],
+        )
         return self.average_pool(model_outputs.last_hidden_state, batch['attention_mask'])
 
     def encode_dense(self, item: dict) -> torch.Tensor:

--- a/deepref/tests/encoder/test_sdp_encoder.py
+++ b/deepref/tests/encoder/test_sdp_encoder.py
@@ -105,10 +105,9 @@ def encoder_verbalized():
     """
     from deepref.encoder.sdp_encoder import VerbalizedSDPEncoder
     mock_model = MagicMock()
-    mock_model.parameters.return_value = iter([])
     mock_tokenizer = MagicMock()
-    with mock.patch('deepref.encoder.llm_encoder.AutoModel.from_pretrained', return_value=mock_model), \
-         mock.patch('deepref.encoder.llm_encoder.AutoTokenizer.from_pretrained', return_value=mock_tokenizer):
+    with mock.patch('deepref.utils.model_registry.AutoModel.from_pretrained', return_value=mock_model), \
+         mock.patch('deepref.utils.model_registry.AutoTokenizer.from_pretrained', return_value=mock_tokenizer):
         enc = VerbalizedSDPEncoder()
     enc.forward = MagicMock(return_value=torch.zeros(1, MOCK_EMBED_DIM))
     return enc


### PR DESCRIPTION
## Summary
- Replace direct `self.model` access in `VerbalizedSDPEncoder.forward()` with `self.registry.run_from_input_ids()`, consistent with how `RelationEncoder` uses the `ModelRegistry`
- Remove manual device placement (`next(self.model.parameters()).device` + `batch.to(device)`) since `ModelRegistry.tokenize()` already moves tensors to the correct device
- Fix test fixture to patch `deepref.utils.model_registry.AutoModel/AutoTokenizer` instead of the unused imports in `deepref.encoder.llm_encoder`

## Test plan
- [x] All 90 non-integration SDP encoder tests pass
- [x] Fixture patches corrected to intercept model loading in `ModelRegistry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)